### PR TITLE
FIX bug in the loop that converts the imported labels to uppercase

### DIFF
--- a/rasm.c
+++ b/rasm.c
@@ -18891,7 +18891,7 @@ printf("paramz\n");
 			i=0;
 			while (labelines[i]) {
 				/* upper case */
-				for (j=0;labelines[i][j];j++) labelines[i][j]=toupper(labelines[i][j]);
+				for (int k=0;labelines[i][k];k++) labelines[i][k]=toupper(labelines[i][k]);
 
 				if ((labelsep1=strstr(labelines[i],": EQU 0"))!=NULL) {
 					/* sjasm */


### PR DESCRIPTION
The loop was reusing the j variable. 
The behaviour was thus very unpredictable and rasm was often crashing when importing symbols files.