### PR TITLE
Respect the -sb and -ss arguments.

### DIFF
--- a/rasm.c
+++ b/rasm.c
@@ -23,7 +23,7 @@ You may send requests/bugs in the same topic
 -----------------------------------------------------------------------------------------------------
 This software is using MIT "expat" license
 
-« Copyright © BERGE Edouard (roudoudou)
+ï¿½ Copyright ï¿½ BERGE Edouard (roudoudou)
 
 Permission  is  hereby  granted,  free  of charge,to any person obtaining a copy  of  this  software
 and  associated  documentation/source   files   of RASM, to deal in the Software without restriction,
@@ -38,7 +38,7 @@ including  but  not  limited  to the warranties of merchantability,   fitness   
 purpose  and  noninfringement.  In  no event shall the  authors  or  copyright  holders be liable for
 any  claim, damages  or other  liability,  whether in  an  action  of  contract, tort  or  otherwise,
 arising from,  out of  or in connection  with  the software  or  the  use  or  other  dealings in the
-Software. »
+Software. ï¿½
 -----------------------------------------------------------------------------------------------------
 Linux compilation with GCC or Clang:
 cc rasm.c -O2 -lm -lrt -march=native -o rasm
@@ -498,7 +498,7 @@ struct s_hfe_action {
 	int ioffset;
 	// deferred calculation info
 	int iw,nbparam;
-	// copie intégrale des paramètres?
+	// copie intï¿½grale des paramï¿½tres?
 	char **param;
 	int iparam,mparam;
 	// extended sector definition
@@ -764,7 +764,7 @@ struct s_rasm_thread {
 /*********************************************************
             S N A P S H O T     E X P O R T
 *********************************************************/
-/* extension 4Mo = 256 slots + 4 slots 64K de RAM par défaut => 260 */
+/* extension 4Mo = 256 slots + 4 slots 64K de RAM par dï¿½faut => 260 */
 
 #define BANK_MAX_NUMBER 260
 
@@ -1356,7 +1356,7 @@ A-Z variable ou fonction (cos, sin, tan, sqr, pow, mod, and, xor, mod, ...)
 +*-/&^m| operateur
 */
 
-#define AutomateExpressionValidCharExtendedDefinition "0123456789.ABCDEFGHIJKLMNOPQRSTUVWXYZ_{}@+-*/~^$#%<=>|&" /* § */
+#define AutomateExpressionValidCharExtendedDefinition "0123456789.ABCDEFGHIJKLMNOPQRSTUVWXYZ_{}@+-*/~^$#%<=>|&" /* ï¿½ */
 #define AutomateExpressionValidCharFirstDefinition "#%0123456789.ABCDEFGHIJKLMNOPQRSTUVWXYZ_@${"
 #define AutomateExpressionValidCharDefinition "0123456789.ABCDEFGHIJKLMNOPQRSTUVWXYZ_{}@$"
 #define AutomateValidLabelFirstDefinition ".ABCDEFGHIJKLMNOPQRSTUVWXYZ_@"
@@ -1419,7 +1419,7 @@ nMaxCompressedSize=65536;
 
 /* RAW */
 nFlags=1<<1; // nFlags=LZSA_FLAG_RAW_BLOCK;
-/* par défaut du LZSA1-Fast */
+/* par dï¿½faut du LZSA1-Fast */
 if (version<1 || version>2) {
 	version=1;
 }
@@ -2092,14 +2092,14 @@ int StringIsMem(char *w)
 					break;
 				case '(':p++;break;
 				case ')':p--;
-					/* si on sort de la première parenthèse */
+					/* si on sort de la premiï¿½re parenthï¿½se */
 					if (!p && w[idx+1]) return 0;
 					break;
 				default:break;
 			}
 			idx++;
 		}
-		/* si on ne termine pas par une parenthèse */
+		/* si on ne termine pas par une parenthï¿½se */
 		if (w[idx-1]!=')') return 0;
 	} else {
 		return 0;
@@ -2717,7 +2717,7 @@ void FreeAssenv(struct s_assenv *ae)
 				debug_symbol.v=ae->label[i].ptr;
 				ObjectArrayAddDynamicValueConcat((void**)&ae->debug.symbol,&ae->debug.nbsymbol,&ae->debug.maxsymbol,&debug_symbol,sizeof(struct s_debug_symbol));
 			} else {
-				/* les labels locaux et générés */
+				/* les labels locaux et gï¿½nï¿½rï¿½s */
 				debug_symbol.name=TxtStrDup(ae->label[i].name);
 				if (ae->label[i].localsize) debug_symbol.name[ae->label[i].localsize]=0;
 				debug_symbol.v=ae->label[i].ptr;
@@ -3236,10 +3236,10 @@ void CheckAndSortAliases(struct s_assenv *ae)
 		}
 	}
 	
-	/* cas particuliers pour insertion en début ou fin de liste */
+	/* cas particuliers pour insertion en dï¿½but ou fin de liste */
 	if (ae->ialias-1) {
 		if (ae->alias[ae->ialias-1].crc>ae->alias[ae->ialias-2].crc) {
-			/* pas de tri il est déjà au bon endroit */
+			/* pas de tri il est dï¿½jï¿½ au bon endroit */
 		} else if (ae->alias[ae->ialias-1].crc<ae->alias[0].crc) {
 			/* insertion tout en bas de liste */
 			tmpalias=ae->alias[ae->ialias-1];
@@ -6065,7 +6065,7 @@ double ComputeExpressionCore(struct s_assenv *ae,char *original_zeexpression,int
 #endif
 						minivarbuffer=TranslateTag(ae,minivarbuffer, &touched,0,E_TAGOPTION_NONE);
 #if TRACE_COMPUTE_EXPRESSION
-	printf("après curly [%s]\n",minivarbuffer);
+	printf("aprï¿½s curly [%s]\n",minivarbuffer);
 #endif
 						ae->computectx=&ae->ctx1;
 						if (!touched) {
@@ -6117,7 +6117,7 @@ double ComputeExpressionCore(struct s_assenv *ae,char *original_zeexpression,int
 						curdic=SearchDico(ae,ae->computectx->varbuffer+minusptr,crc);
 						if (curdic) {
 #if TRACE_COMPUTE_EXPRESSION
-	printf("trouvé valeur=%.2lf\n",curdic->v);
+	printf("trouvï¿½ valeur=%.2lf\n",curdic->v);
 #endif
 							curval=curdic->v;
 							break;
@@ -6129,22 +6129,22 @@ double ComputeExpressionCore(struct s_assenv *ae,char *original_zeexpression,int
 							} else if (strncmp(ae->computectx->varbuffer+minusptr,"{BANK}",6)==0) {
 								bank=6;
 								page=0;
-								/* obligé de recalculer le CRC */
+								/* obligï¿½ de recalculer le CRC */
 								crc=GetCRC(ae->computectx->varbuffer+minusptr+bank);
 							} else if (strncmp(ae->computectx->varbuffer+minusptr,"{PAGE}",6)==0) {
 								bank=6;
 								page=1;
-								/* obligé de recalculer le CRC */
+								/* obligï¿½ de recalculer le CRC */
 								crc=GetCRC(ae->computectx->varbuffer+minusptr+bank);
 							} else if (strncmp(ae->computectx->varbuffer+minusptr,"{PAGESET}",9)==0) {
 								bank=9;
 								page=2;
-								/* obligé de recalculer le CRC */
+								/* obligï¿½ de recalculer le CRC */
 								crc=GetCRC(ae->computectx->varbuffer+minusptr+bank);
 							} else if (strncmp(ae->computectx->varbuffer+minusptr,"{SIZEOF}",8)==0) {
 								bank=8;
 								page=3;
-								/* obligé de recalculer le CRC */
+								/* obligï¿½ de recalculer le CRC */
 								crc=GetCRC(ae->computectx->varbuffer+minusptr+bank);
 								curval=-1;
 								/* search in structures aliases */
@@ -6184,8 +6184,8 @@ double ComputeExpressionCore(struct s_assenv *ae,char *original_zeexpression,int
 							/* limited label translation while processing crunched blocks
 							   ae->curlz == current crunched block processed
 							   expression->crunch_block=0 -> oui
-							   expression->crunch_block=1 -> oui si même block
-							   expression->crunch_block=2 -> non car sera relogée
+							   expression->crunch_block=1 -> oui si mï¿½me block
+							   expression->crunch_block=2 -> non car sera relogï¿½e
 							*/
 							if (page!=3) {
 
@@ -6213,7 +6213,7 @@ if (didx>0 && didx<ae->ie) {
 		curlabel=NULL;
 	}
 
-	/* pas trouvé on cherche LEGACY */
+	/* pas trouvï¿½ on cherche LEGACY */
 	if (!curlabel) {
 		curlabel=SearchLabel(ae,ae->computectx->varbuffer+minusptr+bank,crc);
 #if TRACE_LABEL || TRACE_COMPUTE_EXPRESSION
@@ -6237,7 +6237,7 @@ if (didx>0 && didx<ae->ie) {
 
 		/* on essaie toujours de trouver le label du module courant */	
 		curlabel=SearchLabel(ae,dblvarbuffer,GetCRC(dblvarbuffer));
-		/* pas trouvé on cherche LEGACY */
+		/* pas trouvï¿½ on cherche LEGACY */
 		if (!curlabel) curlabel=SearchLabel(ae,ae->computectx->varbuffer+minusptr+bank,crc);
 #if TRACE_LABEL || TRACE_COMPUTE_EXPRESSION
 		else printf("label trouve via ajout du MODULE\n");
@@ -6247,7 +6247,7 @@ if (didx>0 && didx<ae->ie) {
 	} else {
 		curlabel=SearchLabel(ae,ae->computectx->varbuffer+minusptr+bank,crc);
 #if TRACE_LABEL || TRACE_COMPUTE_EXPRESSION
-		if (curlabel) printf("label trouve sans avoir ajouté de MODULE\n");
+		if (curlabel) printf("label trouve sans avoir ajoutï¿½ de MODULE\n");
 #endif
 	}
 }
@@ -6307,7 +6307,7 @@ printf("page=%d | ptr=%X ibank=%d\n",page,curlabel->ptr,curlabel->ibank);
 										} else {
 											int process_label=1;
 
-											// si on est dans une section crunchée, on doit faire un contrôle étendu du scope du label
+											// si on est dans une section crunchï¿½e, on doit faire un contrï¿½le ï¿½tendu du scope du label
 											if (ae->lzsection[curlabel->lz].lzversion) {
 												/* label MUST be intermediate OR in the crunched block */
 												//if (curlabel->iorgzone==ae->expression[didx].iorgzone) {
@@ -6486,7 +6486,7 @@ printf("stage 2 | page=%d | ptr=%X ibank=%d\n",page,curlabel->ptr,curlabel->iban
 
 										reverse_idx=strlen(ae->computectx->varbuffer)-1;
 										if (ae->computectx->varbuffer[reverse_idx]>='0' && ae->computectx->varbuffer[reverse_idx]<='9') {
-											/* vu que ça ne PEUT PAS être une valeur litérale, on ne fait pas de test de débordement */
+											/* vu que ï¿½a ne PEUT PAS ï¿½tre une valeur litï¿½rale, on ne fait pas de test de dï¿½bordement */
 											reverse_idx--;
 											while (ae->computectx->varbuffer[reverse_idx]>='0' && ae->computectx->varbuffer[reverse_idx]<='9') {
 												reverse_idx--;
@@ -7360,7 +7360,7 @@ double ComputeExpression(struct s_assenv *ae,char *expr, int ptr, int didx, int 
 printf("MakeAlias (1) EXPR=[%s EQU %s]\n",expr,ptr_exp2);
 #endif
 			
-			/* alias locaux ou de proximité */
+			/* alias locaux ou de proximitï¿½ */
 			if (strchr("@.",expr[0])) {
 #if TRACE_COMPUTE_EXPRESSION
 printf("WARNING! alias is local! [%s]\n",expr);
@@ -7810,7 +7810,7 @@ printf("ExpressionFastTranslate (full) -> replace var (%s=%0.1lf)\n",varbuffer,v
 					}
 				}
 			}
-			/* on cherche aussi dans les labels existants => priorité aux modules!!! */   // modulmodif => pas utile?
+			/* on cherche aussi dans les labels existants => prioritï¿½ aux modules!!! */   // modulmodif => pas utile?
 			if (!found_replace) {
 				curlabel=SearchLabel(ae,varbuffer,crc);
 				if (curlabel) {
@@ -8014,7 +8014,7 @@ printf("exprout=[%s]\n",expr);
 								}
 							} else if (ae->forcesnapshot) {
 								if (ae->activebank<BANK_MAX_NUMBER) {
-									/* on autorise le préfixe BANK en snapshot avec une subtilité */
+									/* on autorise le prï¿½fixe BANK en snapshot avec une subtilitï¿½ */
 								if (ae->bankset[ae->activebank>>2]) {
 									tagvalue=ae->activebank+(ae->codeadr>>14); /* dans un bankset on tient compte de l'adresse */
 								} else {
@@ -8186,7 +8186,7 @@ void PushExpression(struct s_assenv *ae,int iw,enum e_expression zetype)
 				case E_EXPRESSION_BRS:break;
 				default:break;
 			}
-			/* hack pourri pour gérer le $ */
+			/* hack pourri pour gï¿½rer le $ */
 			ae->codeadr+=startptr;
 			/* ok mais les labels locaux des macros? */
 
@@ -8535,7 +8535,7 @@ void EDSK_load(struct s_assenv *ae,struct s_edsk_wrapper *curwrap, char *edskfil
 					FreeAssenv(ae);exit(ABORT_ERROR);
 				}
 			}
-			/* piste à piste on lit les blocs DANS L'ORDRE LOGIQUE!!! */
+			/* piste ï¿½ piste on lit les blocs DANS L'ORDRE LOGIQUE!!! */
 			for (b=0xC1;b<=0xC9;b++)
 			for (s=0;s<sectornumber;s++) {
 				if (data[i+24+8*s+2]==b) {
@@ -8632,7 +8632,7 @@ void EDSK_load(struct s_assenv *ae,struct s_edsk_wrapper *curwrap, char *edskfil
 	printf("\n");
 #endif
 
-				/* piste à piste on lit les blocs DANS L'ORDRE LOGIQUE!!! */
+				/* piste ï¿½ piste on lit les blocs DANS L'ORDRE LOGIQUE!!! */
 				for (b=0xC1;b<=0xC9;b++) {
 					tmpcurrentsectorposition=currentsectorposition;
 					for (s=0;s<sectornumber;s++) {
@@ -8661,7 +8661,7 @@ void EDSK_load(struct s_assenv *ae,struct s_edsk_wrapper *curwrap, char *edskfil
 	/* Rasm management of (e)DSK files is AMSDOS compatible, just need to copy CATalog blocks but sort them... */
 	memcpy(&curwrap->entry[0],curwrap->blocks[0],1024);
 	memcpy(&curwrap->entry[32],curwrap->blocks[1],1024);
-	/* tri des entrées selon le user */
+	/* tri des entrï¿½es selon le user */
 	qsort(curwrap->entry,64,sizeof(struct s_edsk_wrapper_entry),cmpAmsdosentry);
 	curwrap->nbentry=64;
 	for (i=0;i<64;i++) {
@@ -8948,10 +8948,10 @@ void EDSK_write_file(struct s_assenv *ae,struct s_edsk_wrapper *faceA,struct s_e
 	
 	if (!faceA && !faceB) return;
 	
-	/* création des deux blocs du directory par face */
+	/* crï¿½ation des deux blocs du directory par face */
 	EDSK_build_amsdos_directory(faceA);
 	EDSK_build_amsdos_directory(faceB);
-	/* écriture header */
+	/* ï¿½criture header */
 	strcpy((char *)header,"EXTENDED CPC DSK File\r\nDisk-Info\r\n");
 	sprintf(headertag,"%-9.9s",RASM_SNAP_VERSION);
 	strcpy((char *)header+0x22,headertag);
@@ -8972,7 +8972,7 @@ void EDSK_write_file(struct s_assenv *ae,struct s_edsk_wrapper *faceA,struct s_e
 #endif
 	FileWriteBinary(faceA->edsk_filename,(char *)header,256);
 	
-	/* écriture des pistes */
+	/* ï¿½criture des pistes */
 	for (t=0;t<40;t++) {
 		strcpy((char *)trackblock,"Track-Info\r\n");
 		trackblock[0x10]=t;
@@ -9013,15 +9013,15 @@ void EDSK_write_file(struct s_assenv *ae,struct s_edsk_wrapper *faceA,struct s_e
 #if TRACE_EDSK
 	if (t<3) printf("\n"); else if (t==3) printf("...\n");
 #endif
-		/* écriture du track info */
+		/* ï¿½criture du track info */
 		FileWriteBinary(faceA->edsk_filename,(char *)trackblock,256);
 
 
-		/* il faut convertir les blocs logiques en secteurs physiques ET entrelacés */
+		/* il faut convertir les blocs logiques en secteurs physiques ET entrelacï¿½s */
 		idblock=t*9/2;
 		blockoffset=((t*9)%2)*512;
 
-		/* le premier secteur de la piste est à cheval sur le bloc logique une fois sur deux */
+		/* le premier secteur de la piste est ï¿½ cheval sur le bloc logique une fois sur deux */
 		FileWriteBinary(faceA->edsk_filename,(char *)&faceA->blocks[idblock][0]+blockoffset,512); /* C1 */
 		if (!blockoffset) {
 			FileWriteBinary(faceA->edsk_filename,(char *)&faceA->blocks[idblock+2][0]+512,512); /* C6 */
@@ -9043,7 +9043,7 @@ void EDSK_write_file(struct s_assenv *ae,struct s_edsk_wrapper *faceA,struct s_e
 			FileWriteBinary(faceA->edsk_filename,(char *)&faceA->blocks[idblock+2][0]+512,512); /* C5 */
 		}
 
-		/* @@TODO ça semble un peu foireux comme procédé */	
+		/* @@TODO ï¿½a semble un peu foireux comme procï¿½dï¿½ */	
 		if (faceB) {
 #if TRACE_EDSK
 	printf("writing EDSK face B /!\\  probably NOT WORKING !!!\n");
@@ -9053,9 +9053,9 @@ void EDSK_write_file(struct s_assenv *ae,struct s_edsk_wrapper *faceA,struct s_e
 				trackblock[0x18+i*8+0]=trackblock[0x10];
 				trackblock[0x18+i*8+1]=trackblock[0x11];
 			}
-			/* écriture du track info */
+			/* ï¿½criture du track info */
 			FileWriteBinary(faceB->edsk_filename,(char *)trackblock,256);
-			/* écriture des secteurs */
+			/* ï¿½criture des secteurs */
 			idblock=t*9/2;
 			blockoffset=((t*9)%2)*512;
 			FileWriteBinary(faceB->edsk_filename,(char *)&faceB->blocks[idblock][0]+blockoffset,512);
@@ -9303,7 +9303,7 @@ void PopAllSave(struct s_assenv *ae)
 		/* DSK management */
 		if (ae->save[is].dsk) {
 			if (ae->save[is].iwdskname!=-1) {
-				/* obligé de dupliquer à cause du reuse */
+				/* obligï¿½ de dupliquer ï¿½ cause du reuse */
 				dskfilename=TxtStrDup(ae->wl[ae->save[is].iwdskname].w);
 				dskfilename[strlen(dskfilename)-1]=0;
 				if (!EDSK_addfile(ae,dskfilename+1,ae->save[is].face,filename,ae->mem[ae->save[is].ibank]+offset,size,offset,run)) {
@@ -9372,7 +9372,7 @@ void PopAllExpression(struct s_assenv *ae, int crunched_zone)
 
 	   idealement on doit tolerer les adresses situees apres le crunch dans une autre ORG zone!
 
-	   on utilise ae->stage pour créer un état intermédiaire dans le ComputeExpressionCore
+	   on utilise ae->stage pour crï¿½er un ï¿½tat intermï¿½diaire dans le ComputeExpressionCore
 	*/
 	if (crunched_zone>=0) {
 		ae->stage=1;
@@ -9834,7 +9834,7 @@ printf("PUSH Orphan PROXIMITY label that cannot be exported [%s]->[%s]\n",ae->wl
 	else printf("PUSH => NO MODULE for local label\n");
 #endif
 
-			/* contrôle dico uniquement avec des labels non locaux */
+			/* contrï¿½le dico uniquement avec des labels non locaux */
 			if (SearchDico(ae,curlabel.name,curlabel.crc)) {
 				MakeError(ae,ae->idx,GetCurrentFile(ae),ae->wl[ae->idx].l,"cannot create label [%s] as there is already a variable with the same name\n",curlabel.name);
 				return;
@@ -12627,9 +12627,9 @@ void _DEFF_struct(struct s_assenv *ae) {
 			ae->idx++;
 			/* conversion des symboles connus */
 			ExpressionFastTranslate(ae,&ae->wl[ae->idx].w,0);
-			/* calcul de la valeur définitive de l'expression */
+			/* calcul de la valeur dï¿½finitive de l'expression */
 			v=ComputeExpressionCore(ae,ae->wl[ae->idx].w,ae->outputadr,0);
-			/* conversion en réel Amsdos */
+			/* conversion en rï¿½el Amsdos */
 			rc=__internal_MakeRosoftREAL(ae,v,0);
 			___output(ae,rc[0]);___output(ae,rc[1]);___output(ae,rc[2]);___output(ae,rc[3]);___output(ae,rc[4]);			
 		} while (ae->wl[ae->idx].t==0);
@@ -12665,9 +12665,9 @@ void _DEFR_struct(struct s_assenv *ae) {
 			ae->idx++;
 			/* conversion des symboles connus */
 			ExpressionFastTranslate(ae,&ae->wl[ae->idx].w,0);
-			/* calcul de la valeur définitive de l'expression */
+			/* calcul de la valeur dï¿½finitive de l'expression */
 			v=ComputeExpressionCore(ae,ae->wl[ae->idx].w,ae->outputadr,0);
-			/* conversion en réel Amsdos */
+			/* conversion en rï¿½el Amsdos */
 			rc=__internal_MakeAmsdosREAL(ae,v,0);
 			___output(ae,rc[0]);___output(ae,rc[1]);___output(ae,rc[2]);___output(ae,rc[3]);___output(ae,rc[4]);			
 		} while (ae->wl[ae->idx].t==0);
@@ -13068,7 +13068,7 @@ void __hfe_init(struct s_assenv *ae, struct s_hfe_action *hfe_action) {
 	struct s_hfe_floppy hfeflop={0};
 	ae->hfeside=0;
 	ae->hfetrack=0;
-	// remplir une struct HFE par défaut
+	// remplir une struct HFE par dï¿½faut
 	ObjectArrayAddDynamicValueConcat((void **)&ae->hfedisk,&ae->nbhfedisk,&ae->maxhfedisk,&hfeflop,sizeof(hfeflop));
 	ae->hfedisk[ae->nbhfedisk-1].filename=hfe_action->filename;
 	// current pointer
@@ -13268,7 +13268,7 @@ void __hfe_add_sector(struct s_assenv *ae, struct s_hfe_action *hfe_action) {
 	zebyte=crc&0xFF; // CRC low weight
 	ObjectArrayAddDynamicValueConcat((void **)&ae->hfe->data,&ae->hfe->idata,&ae->hfe->mdata,&zebyte,sizeof(zebyte));
 
-	// gestion des longueurs à la con
+	// gestion des longueurs ï¿½ la con
 	switch (sectorsize) {
 		case 0:curlen=128;break;
 		case 1:curlen=256;break;
@@ -13591,7 +13591,7 @@ struct s_edsk_global_struct *edsktool_NewEDSK(char *format) {
         return edsk;
 }
 
-struct s_edsk_global_struct *edsktool_EDSK_load(char *edskfilename) //@@TODO faire un mécanisme de cache
+struct s_edsk_global_struct *edsktool_EDSK_load(char *edskfilename) //@@TODO faire un mï¿½canisme de cache
 {
         #undef FUNC
         #define FUNC "EDSK_load"
@@ -13823,7 +13823,7 @@ void edsktool_EDSK_write_file(struct s_edsk_global_struct *edsk, char *output_fi
 
 	FileRemoveIfExists(output_filename);
 
-        /* écriture header */
+        /* ï¿½criture header */
         strcpy((char *)header,"EXTENDED CPC DSK File\r\nDisk-Info\r\n");
         sprintf(headertag,"%-9.9s","edskt");
         strcpy((char *)header+0x22,headertag);
@@ -13847,7 +13847,7 @@ void edsktool_EDSK_write_file(struct s_edsk_global_struct *edsk, char *output_fi
 
 	FileWriteBinary(output_filename,(char*)header,256);
 
-        /* écriture des pistes */
+        /* ï¿½criture des pistes */
         for (t=0;t<edsk->tracknumber;t++)
         for (face=0;face<edsk->sidenumber;face++) {
                 curtrack=t*edsk->sidenumber+face;
@@ -14822,7 +14822,7 @@ void __EDSK(struct s_assenv *ae) {
 		// which action?
 		switch (ae->wl[ae->idx+1].w[0]) {
 			case 'A':if (strcmp(ae->wl[ae->idx+1].w,"ADD")==0)	curaction.action=E_EDSK_ACTION_ADD; else cmderr=1;break; // add sector
-			case 'C':if (strcmp(ae->wl[ae->idx+1].w,"CREATE")==0)	curaction.action=E_EDSK_ACTION_CREATE; else cmderr=1;break; // nombre de pistes + format éventuel
+			case 'C':if (strcmp(ae->wl[ae->idx+1].w,"CREATE")==0)	curaction.action=E_EDSK_ACTION_CREATE; else cmderr=1;break; // nombre de pistes + format ï¿½ventuel
 			case 'D':if (strcmp(ae->wl[ae->idx+1].w,"DROP")==0)	curaction.action=E_EDSK_ACTION_DROP; else cmderr=1;break; // drop track or sector
 			case 'G':if (strcmp(ae->wl[ae->idx+1].w,"GAPFIX")==0)	curaction.action=E_EDSK_ACTION_GAPFIX; else cmderr=1;break; // fix GAP to fit an ideal track
 			case 'M':if (strcmp(ae->wl[ae->idx+1].w,"MERGE")==0)	curaction.action=E_EDSK_ACTION_MERGE; else // merge edsk
@@ -14876,7 +14876,7 @@ void __EDSK(struct s_assenv *ae) {
 		/*
 		cursave.ioffset=ae->idx+2;
 		cursave.isize=ae->idx+3;
-		ExpressionFastTranslate(ae,&ae->wl[ae->idx+2].w,1); // si on utilise des variables ça évite la grouille post traitement...
+		ExpressionFastTranslate(ae,&ae->wl[ae->idx+2].w,1); // si on utilise des variables ï¿½a ï¿½vite la grouille post traitement...
 		ExpressionFastTranslate(ae,&ae->wl[ae->idx+3].w,1); // idem
 		*/
 
@@ -15433,7 +15433,7 @@ void __SNAPINIT(struct s_assenv *ae) {
 	if (!ae->forcecpr && !ae->forcetape && !ae->forceROM) {
 		// automatic BUILDSNA
 		ae->forcesnapshot=1;
-		ae->remu=1;
+	//	ae->remu=1;
 	}
 
 	if (!ae->wl[ae->idx].t) {
@@ -15615,7 +15615,7 @@ void __BUILDSNA(struct s_assenv *ae) {
 	}
 	if (!ae->forcecpr && !ae->forcetape && !ae->forcezx && !ae->forceROM) {
 		ae->forcesnapshot=1;
-		ae->remu=1;
+	//	ae->remu=1;
 	} else {
 		MakeError(ae,ae->idx,GetCurrentFile(ae),ae->wl[ae->idx].l,"Cannot select snapshot output when already in ZX/ROM/cartridge/tape output\n");
 	}
@@ -16183,7 +16183,7 @@ void __ROMBANK(struct s_assenv *ae) {
 		MakeError(ae,ae->idx,GetCurrentFile(ae),ae->wl[ae->idx].l,"ROMBANK can be used only with snapshot output\n");
 		return;
 	}
-	ae->remu=1; // force REMU output :)
+	//ae->remu=1; // force REMU output :)
 
 	if (!ae->wl[ae->idx].t) {
 		if (strcmp(ae->wl[ae->idx+1].w,"LOWER")==0) {
@@ -16229,7 +16229,7 @@ void __BANKSET(struct s_assenv *ae) {
 		ae->orgzone[ae->io-1].memend=ae->outputadr;
 	}
 	ae->bankmode=1;
-	ae->remu=1;
+	//ae->remu=1; // I guess there is no reason to force it here. Otherwise standard ACE chuncks are not generated
 	
 	if (ae->wl[ae->idx+1].t!=2) {
 		ExpressionFastTranslate(ae,&ae->wl[ae->idx+1].w,0);
@@ -16565,7 +16565,7 @@ void __MACRO(struct s_assenv *ae) {
 			MakeError(ae,ae->idx,GetCurrentFile(ae),ae->wl[ae->idx].l,"Macro was not closed\n");
 		}
 		ObjectArrayAddDynamicValueConcat((void**)&ae->macro,&ae->imacro,&ae->mmacro,&curmacro,sizeof(curmacro));
-		/* le quicksort n'est pas optimal mais on n'est pas supposé en créer des milliers */
+		/* le quicksort n'est pas optimal mais on n'est pas supposï¿½ en crï¿½er des milliers */
 		qsort(ae->macro,ae->imacro,sizeof(struct s_macro),cmpmacros);
 
 		/* ajustement des mots lus */
@@ -16729,7 +16729,7 @@ struct s_wordlist *__MACRO_EXECUTE(struct s_assenv *ae, int imacro) {
 				ae->nbword+=ae->macro[imacro].nbword-1-nbparam-reload;
 				ae->wl=MemRealloc(ae->wl,ae->nbword*sizeof(struct s_wordlist));
 			} else {
-				/* si on réduit pas de realloc pour ne pas perdre de donnees */
+				/* si on rï¿½duit pas de realloc pour ne pas perdre de donnees */
 				ae->nbword+=ae->macro[imacro].nbword-1-nbparam-reload;
 			}
 			iline=ae->wl[ae->idx].l;
@@ -17666,7 +17666,7 @@ void __WHILE(struct s_assenv *ae) {
 			whilewend.maxim=ae->imacropos;
 			whilewend.while_counter=1;
 			ae->whilecounter++;
-			/* pour gérer les macros situés dans le while précedent après un repeat/while courant */
+			/* pour gï¿½rer les macros situï¿½s dans le while prï¿½cedent aprï¿½s un repeat/while courant */
 			if (ae->iw) whilewend.maxim=ae->whilewend[ae->iw-1].maxim;
 			if (ae->ir && ae->repeat[ae->ir-1].maxim>whilewend.maxim) whilewend.maxim=ae->repeat[ae->ir-1].maxim;
 			ObjectArrayAddDynamicValueConcat((void**)&ae->whilewend,&ae->iw,&ae->mw,&whilewend,sizeof(whilewend));
@@ -17775,7 +17775,7 @@ void __REPEAT(struct s_assenv *ae) {
 				if ((rvar=SearchDico(ae,ae->wl[ae->idx].w,crc))!=NULL) {
 					rvar->v=vstart;
 				} else {
-					/* mais ne peut être un label ou un alias */
+					/* mais ne peut ï¿½tre un label ou un alias */
 					ExpressionSetDicoVar(ae,ae->wl[ae->idx].w,vstart,0);
 					rvar=SearchDico(ae,ae->wl[ae->idx].w,crc);
 				}
@@ -17799,7 +17799,7 @@ void __REPEAT(struct s_assenv *ae) {
 		currepeat.value=ae->repeatcounter;
 		currepeat.repeat_counter=1;
 		ae->repeatcounter++;
-		/* pour gérer les macros situés dans le repeat précedent après le repeat courant */
+		/* pour gï¿½rer les macros situï¿½s dans le repeat prï¿½cedent aprï¿½s le repeat courant */
 		if (ae->ir) currepeat.maxim=ae->repeat[ae->ir-1].maxim;
 		if (ae->iw && ae->whilewend[ae->iw-1].maxim>currepeat.maxim) currepeat.maxim=ae->whilewend[ae->iw-1].maxim;
 		if (ae->imacropos>currepeat.maxim) currepeat.maxim=ae->imacropos;
@@ -18427,7 +18427,7 @@ void ___org_new(struct s_assenv *ae, int nocode) {
 	
 	/* check current ORG request */
 	for (i=0;i<ae->io;i++) {
-		/* aucun contrôle sur les ORG non écrits ou en NOCODE */
+		/* aucun contrï¿½le sur les ORG non ï¿½crits ou en NOCODE */
 		if (ae->orgzone[i].memstart!=ae->orgzone[i].memend && !ae->orgzone[i].nocode) {
 			if (ae->orgzone[i].ibank==ae->activebank) {
 				if (ae->outputadr<ae->orgzone[i].memend && ae->outputadr>=ae->orgzone[i].memstart) {
@@ -18731,11 +18731,11 @@ printf("pushLight [%s] %d:%X\n",curlabel.name,curlabel.ibank,curlabel.ptr);
 #if TRACE_STRUCT
 printf("struct new behaviour (scan for %d fields)\n",ae->rasmstruct[irs].irasmstructfield);
 #endif
-				/* déterminer si on est en remplissage par défaut ou remplissage surchargé */
+				/* dï¿½terminer si on est en remplissage par dï¿½faut ou remplissage surchargï¿½ */
 				for (i=0;i<ae->rasmstruct[irs].irasmstructfield;i++) {
 
 					if (!ae->wl[ae->idx+2+i].t || i+1>=ae->rasmstruct[irs].irasmstructfield) {
-						/* si le champ est sur le même offset que le précédent, on le saute */
+						/* si le champ est sur le mï¿½me offset que le prï¿½cï¿½dent, on le saute */
 						if (i && ae->rasmstruct[irs].rasmstructfield[i].offset>ae->rasmstruct[irs].rasmstructfield[i-1].offset) continue;
 
 #if TRACE_STRUCT
@@ -18765,7 +18765,7 @@ printf("*break*\n");
 				}
 #endif
 
-				/* (LEGACY) filler, on balance des zéros en attendant d'avoir la complétion par init */
+				/* (LEGACY) filler, on balance des zï¿½ros en attendant d'avoir la complï¿½tion par init */
 #if TRACE_STRUCT
 printf("struct (almost) legacy filler from %d to %d-1\n",localsize,ae->rasmstruct[irs].size);
 #endif
@@ -18800,7 +18800,7 @@ printf("struct (almost) legacy filler from %d to %d-1\n",localsize,ae->rasmstruc
 #if 0
 				for (i=localsize;i<ae->rasmstruct[irs].size;i++) ___output(ae,0);
 #endif
-				ae->idx+=2; // probablement à revoir dans le cas d'une init!!!
+				ae->idx+=2; // probablement ï¿½ revoir dans le cas d'une init!!!
 			}
 		}
 	} else {
@@ -19128,11 +19128,11 @@ printf("AudioLoadSample filesize=%d st=%d normalize=%.2lf\n",filesize,sample_typ
 		
 		idx=subchunk-data;
 	} else {
-		// lecture brute du fichier car il ne ressemble pas à un WAV :)
+		// lecture brute du fichier car il ne ressemble pas ï¿½ un WAV :)
 		idx=0;
 		nbchannel=1;
 		nbsample=filesize;
-		_internal_getsample=__internal_getsample8; // 8 bits signés
+		_internal_getsample=__internal_getsample8; // 8 bits signï¿½s
 	}
 
 	switch (sample_type) {
@@ -19155,7 +19155,7 @@ printf("AudioLoadSample filesize=%d st=%d normalize=%.2lf\n",filesize,sample_typ
 			}
 			break;
 		case AUDIOSAMPLE_SM2:
-			/* +1 pour éviter le segfault */
+			/* +1 pour ï¿½viter le segfault */
 			for (i=0;i<nbsample+1;i+=2) {
 				for (j=0;j<2;j++) {
 					/* downmixing */
@@ -19182,7 +19182,7 @@ printf("AudioLoadSample filesize=%d st=%d normalize=%.2lf\n",filesize,sample_typ
 				  10 -> 14 // 3/4
 				  11 -> 15 // 4/4			
 			***/
-			/* +3 pour éviter le segfault */
+			/* +3 pour ï¿½viter le segfault */
 			for (i=0;i<nbsample+3;i+=4) {
 				for (j=0;j<4;j++) {
 					/* downmixing */
@@ -19283,7 +19283,7 @@ fprintf(stderr,"no AP-Ultra support in this version!\n");
 #endif
 
 /*
-	meta fonction qui gère le INCBIN standard plus les variantes SMP et DMA
+	meta fonction qui gï¿½re le INCBIN standard plus les variantes SMP et DMA
 */
 void __READ(struct s_assenv *ae) {
 	if (!ae->wl[ae->idx].t) {
@@ -19461,7 +19461,7 @@ printf(" -> VTILES loading\n");
 									if ((rvar=SearchDico(ae,ae->wl[ae->idx+6].w,crc))!=NULL) {
 										rvar->v=ae->hexbin[hbinidx].rawlen;
 									} else {
-										/* mais ne peut être un label ou un alias */
+										/* mais ne peut ï¿½tre un label ou un alias */
 										ExpressionSetDicoVar(ae,ae->wl[ae->idx+6].w,ae->hexbin[hbinidx].rawlen,0);
 									}
 									ae->idx+=6;
@@ -19501,7 +19501,7 @@ printf("we look for tags in the name of a file which were not found\n");
 			for (lm=touched=0;newfilename[lm];lm++) {
 				if (newfilename[lm]=='{') touched++; else if (newfilename[lm]=='}') touched--; else if (touched) newfilename[lm]=toupper(newfilename[lm]);
 			}
-			/* on essaie d'interpréter le nom du fichier en dynamique */
+			/* on essaie d'interprï¿½ter le nom du fichier en dynamique */
 			newfilename=TranslateTag(ae,newfilename,&touched,1,E_TAGOPTION_REMOVESPACE);
 
 			/* Where is the file to load? */
@@ -19630,7 +19630,7 @@ printf("Hexbin -> %s\n",ae->wl[ae->idx+2].w);
 				/* pre-parametres OK (longueur+IDX struct) */
 				if (size<0) {
 #if TRACE_HEXBIN
-printf("taille négative %d -> conversion en %d\n",size,ae->hexbin[hbinidx].datalen+size);
+printf("taille nï¿½gative %d -> conversion en %d\n",size,ae->hexbin[hbinidx].datalen+size);
 #endif
 					size=ae->hexbin[hbinidx].datalen+size;
 					if (size<1) {
@@ -19640,7 +19640,7 @@ printf("taille négative %d -> conversion en %d\n",size,ae->hexbin[hbinidx].datal
 				/* negative offset conversion */
 				if (offset<0) {
 #if TRACE_HEXBIN
-printf("offset négatif %d -> conversion en %d\n",offset,ae->hexbin[hbinidx].datalen+offset);
+printf("offset nï¿½gatif %d -> conversion en %d\n",offset,ae->hexbin[hbinidx].datalen+offset);
 #endif
 					offset=ae->hexbin[hbinidx].datalen+offset;
 				}
@@ -19665,7 +19665,7 @@ printf("taille nulle et offset=%d -> conversion en %d\n",offset,size);
 						int outputidx=0;
 						outputdata=MemMalloc(ae->hexbin[hbinidx].datalen);
 #if TRACE_HEXBIN
-printf("output fictif pour réorganiser les données\n");
+printf("output fictif pour rï¿½organiser les donnï¿½es\n");
 #endif
 
 						if (revert) {
@@ -19946,7 +19946,7 @@ void __SAVE(struct s_assenv *ae) {
 				if (!ae->wl[ae->idx+2].t && ae->wl[ae->idx+3].t!=2) {
 					cursave.ibank=ae->activebank;
 					cursave.ioffset=ae->idx+2;
-					ExpressionFastTranslate(ae,&ae->wl[ae->idx+2].w,1); // si on utilise des variables ça évite la grouille post traitement...
+					ExpressionFastTranslate(ae,&ae->wl[ae->idx+2].w,1); // si on utilise des variables ï¿½a ï¿½vite la grouille post traitement...
 					cursave.isize=ae->idx+3;
 					ExpressionFastTranslate(ae,&ae->wl[ae->idx+3].w,1); // idem
 					if (!touched) cursave.iw=ae->idx+1; else cursave.filename=filename;
@@ -21445,7 +21445,7 @@ int Assemble(struct s_assenv *ae, unsigned char **dataout, int *lenout, struct s
 #endif
 
 		for (i=0;i<ae->ilz;i++) {
-			/* on dépile les symboles dans l'ordre mais on ne reloge pas sur les zones intermédiaires ou post-crunched */
+			/* on dï¿½pile les symboles dans l'ordre mais on ne reloge pas sur les zones intermï¿½diaires ou post-crunched */
 			if (ae->lzsection[i].lzversion!=0) {
 				if (ae->lzsection[i].memend==-1) {
 					/* patch idx */
@@ -21772,7 +21772,7 @@ int Assemble(struct s_assenv *ae, unsigned char **dataout, int *lenout, struct s
 		
 		/* enregistrement des fichiers programmes par la directive SAVE */
 		PopAllSave(ae);
-		/* exécution des actions programmées par la directive EDSK */
+		/* exï¿½cution des actions programmï¿½es par la directive EDSK */
 		PopAllEDSK(ae);
 		PopAllHFE(ae);
 
@@ -22286,7 +22286,7 @@ int Assemble(struct s_assenv *ae, unsigned char **dataout, int *lenout, struct s
 									break;
 								}
 							} else {
-								/* compression par défaut avec snapshot v3 */
+								/* compression par dï¿½faut avec snapshot v3 */
 								rlebank=EncodeSnapshotRLE(packed,&ChunkSize,65536);
 								
 								if (bankset>=0 && bankset<=8) {
@@ -22569,7 +22569,7 @@ int Assemble(struct s_assenv *ae, unsigned char **dataout, int *lenout, struct s
 				}
 				FileRemoveIfExists(TMP_filename);
 
-				/* en mode binaire classique on va recherche le dernier espace mémoire dans lequel on a travaillé qui n'est pas en 'nocode' */
+				/* en mode binaire classique on va recherche le dernier espace mï¿½moire dans lequel on a travaillï¿½ qui n'est pas en 'nocode' */
 				for (i=0;i<ae->io;i++) {
 					/* uniquement si le ORG a ete suivi d'ecriture */
 					if (ae->orgzone[i].memstart!=ae->orgzone[i].memend && ae->orgzone[i].nocode!=1) {
@@ -23436,7 +23436,7 @@ void EarlyPrepSrc(struct s_assenv *ae, char **listing, char *filename) {
 			}
 
 			if (listing[l][idx]=='\\') {
-				/* fusion avec la ligne suivante qui est obligatoirement présente */
+				/* fusion avec la ligne suivante qui est obligatoirement prï¿½sente */
 				listing[l]=MemRealloc(listing[l],strlen(listing[l])+strlen(listing[l+1])+1);
 				strcpy(listing[l]+idx,listing[l+1]);
 				strcpy(listing[l+1],"");
@@ -23833,7 +23833,7 @@ printf("nbbank=%d initialised\n",ae->nbbank);
 	} else {
 		ae->outputfilename=TxtStrDup("rasmoutput");
 	}
-	/* si on est en ligne de commande ET que le fichier n'est pas trouvé */
+	/* si on est en ligne de commande ET que le fichier n'est pas trouvï¿½ */
 	if (param && param->filename && !FileExists(param->filename)) {
 		char *LTryExtension[]={".asm",".z80",".inc",".src",".dam",".mxm",".txt",
 					".ASM",".Z80",".INC",".SRC",".DAM",".MXM",".TXT",".o",".s",".O",".S","",NULL};
@@ -23936,7 +23936,7 @@ printf("nbbank=%d initialised\n",ae->nbbank);
 	Automate[',']=2;
 	Automate['\t']=2;
 	/* end of line */
-	Automate[':']=3; /* les 0x0A et 0x0D seront deja  remplaces en ':' */
+	Automate[':']=3; /* les 0x0A et 0x0D seront dejaï¿½ remplaces en ':' */
 	/* expression */
 	Automate['=']=4; /* on stocke l'emplacement de l'egalite */
 	Automate['<']=4; /* ou des operateurs */
@@ -23967,7 +23967,7 @@ printf("read file/flux\n");
 		int flux_nblines=0;
 		int flux_curpos;
 
-		/* copie des données */
+		/* copie des donnï¿½es */
 		for (i=0;i<datalen;i++) {
 			if (datain[i]=='\n') flux_nblines++;
 		}
@@ -23980,7 +23980,7 @@ printf("read file/flux\n");
 				zelines[flux_nblines]=MemMalloc(i-flux_curpos+2);
 				/* copy data+CR */
 				memcpy(zelines[flux_nblines],datain+flux_curpos,i-flux_curpos+1);
-				/* et on ajoute un petit zéro à la fin! */
+				/* et on ajoute un petit zï¿½ro ï¿½ la fin! */
 				zelines[flux_nblines][i-flux_curpos+1]=0;
 #if 0
 if (flux_nblines<50) printf("%02d[%s]\n",flux_nblines,zelines[flux_nblines]);
@@ -24240,7 +24240,7 @@ if (!idx) printf("[%s]\n",listing[l].listing);
 								ae->rawfile[ae->ifile-1]=ae->source_bigbuffer;
 								ae->rawlen[ae->ifile-1]=ae->source_bigbuffer_len;
 							}
-							/* virer les commentaires + pré-traitement */
+							/* virer les commentaires + prï¿½-traitement */
 							EarlyPrepSrc(ae,listing_include,ae->filename[ae->ifile-1]);
 
 							/* split de la ligne en cours + suppression de l'instruction include */
@@ -24425,7 +24425,7 @@ if (!idx) printf("[%s]\n",listing[l].listing);
 						break;
 
 					case 'U':
-						/* code dupliqué du REND */
+						/* code dupliquï¿½ du REND */
 						if (strcmp(bval,"UNTIL")==0) {
 							/* retrouver la structure repeat_index correspondant a l'ouverture */
 							for (ri=nri-1;ri>=0;ri--) {
@@ -24452,7 +24452,7 @@ if (!idx) printf("[%s]\n",listing[l].listing);
 							if (c==quote_type) {
 								waiting_quote=2;
 							}
-						/* code dupliqué du UNTIL */
+						/* code dupliquï¿½ du UNTIL */
 						} else if (strcmp(bval,"REND")==0) {
 							/* retrouver la structure repeat_index correspondant a l'ouverture */
 							for (ri=nri-1;ri>=0;ri--) {
@@ -24599,7 +24599,7 @@ printf("c='%c' automate[c]=%d\n",c>31?c:'.',Automate[((int)c)&0xFF]);
 #if TRACE_PREPRO
 printf("quote\n");
 #endif
-						/* on finalise le mot si on est en début d'une nouvelle instruction ET que c'est un SAVE */
+						/* on finalise le mot si on est en dï¿½but d'une nouvelle instruction ET que c'est un SAVE */
 						if (strcmp(w,"SAVE")==0) {
 							// on ne break pas pour passer dans le case 2 (separator)
 							idx--;
@@ -24614,7 +24614,7 @@ printf("quote\n");
 #if TRACE_PREPRO
 printf("quote\n");
 #endif
-						/* on finalise le mot si on est en début d'une nouvelle instruction ET que c'est un SAVE */
+						/* on finalise le mot si on est en dï¿½but d'une nouvelle instruction ET que c'est un SAVE */
 						if (strcmp(w,"SAVE")==0) {
 							// on ne break pas pour passer dans le case 2 (separator)
 							idx--;
@@ -24666,7 +24666,7 @@ printf("conversion OR vers |\n");
 printf("*** separator='%c'\n",c);
 #endif
 					
-					/* patch argument suit une expression d'évaluation (ASSERT) */
+					/* patch argument suit une expression d'ï¿½valuation (ASSERT) */
 					if (c==',') hadcomma=1;
 					
 					if (lw) {
@@ -24687,7 +24687,7 @@ printf("2/2 Winape maxam operator test for expression [%s]\n",w+ispace);
 							} else {
 								wtmp=TxtStrDup(w);
 							}
-							/* on concatène le nouveau mot à l'expression */
+							/* on concatï¿½ne le nouveau mot ï¿½ l'expression */
 							nbword--;
 							lw=0;
 							for (li=0;wordlist[nbword].w[li];li++) {
@@ -24820,7 +24820,7 @@ printf("EOL\n");
 					Automate['\t']=2;
 					ispace=0;
 					texpr=0;
-					/* si le mot lu a plus d'un caractère */
+					/* si le mot lu a plus d'un caractï¿½re */
 					if (lw) {
 						if (!wordlist[nbword-1].t && (wordlist[nbword-1].e || w[0]=='=') && !hadcomma) {
 							/* cas particulier d'ecriture libre */
@@ -24860,7 +24860,7 @@ printf("%s\n",wordlist[nbword].w);
 							Automate[' ']=1;
 							Automate['\t']=1;
 						} else {
-							/* mot de fin de ligne, à priori pas une expression */
+							/* mot de fin de ligne, ï¿½ priori pas une expression */
 							curw.w=TxtStrDup(w);
 							curw.l=listing[l].iline;
 							curw.ifile=listing[l].ifile;
@@ -24879,7 +24879,7 @@ if (curw.w[0]=='=') {
 							hadcomma=0;
 						}
 					} else {
-						/* sinon c'est le précédent qui était terminateur d'instruction */
+						/* sinon c'est le prï¿½cï¿½dent qui ï¿½tait terminateur d'instruction */
 						wordlist[nbword-1].t=1;
 						w[lw]=0;
 					}
@@ -24921,7 +24921,7 @@ printf("*** patch prepro operator assignment + useless spacing\n");
 							w[lw]=0;
 						}
 					} else {
-						/* 2018.06.06 évolution sur le ! (not) */
+						/* 2018.06.06 ï¿½volution sur le ! (not) */
 #if TRACE_PREPRO
 printf("*** operateur commence le mot\n");
 printf("mot precedent=[%s] t=%d\n",wordlist[nbword-1].w,wordlist[nbword-1].t);
@@ -24931,7 +24931,7 @@ printf("mot precedent=[%s] t=%d\n",wordlist[nbword-1].w,wordlist[nbword-1].t);
 							w[lw++]=c;
 							StateMachineResizeBuffer(&w,lw,&mw);
 							w[lw]=0;
-							/* automate déjà modifié rien de plus */
+							/* automate dï¿½jï¿½ modifiï¿½ rien de plus */
 						} else if (!wordlist[nbword-1].t) {
 							/* il y avait un mot avant alors on va reorganiser la ligne */
 							/* patch NOT -> SAUF si c'est une directive */
@@ -25040,18 +25040,18 @@ printf("quote start with %c\n",c);
 					if ((unsigned char)w[utidx]>126) {
 						switch ((unsigned char)w[utidx]) {
 							case 0xC2:
-								if ((unsigned char)w[utidx+1]==0xBF) w[utidx]=174; else // ¿
-								if ((unsigned char)w[utidx+1]==0xA1) w[utidx]=175; else // ¡
+								if ((unsigned char)w[utidx+1]==0xBF) w[utidx]=174; else // ï¿½
+								if ((unsigned char)w[utidx+1]==0xA1) w[utidx]=175; else // ï¿½
 									MakeError(ae,0,ae->filename[listing[l].ifile],listing[l].iline,"Unsupported UTF8 char for quoted string\n");
 								break;
 							case 0xC3:
-								if ((unsigned char)w[utidx+1]==0xB9) w[utidx]=124; else // ù
-								if ((unsigned char)w[utidx+1]==0xA9) w[utidx]=123; else // é
-								if ((unsigned char)w[utidx+1]==0xA8) w[utidx]=125; else // è
-								if ((unsigned char)w[utidx+1]==0xA0) w[utidx]=64; else  // à
-								if ((unsigned char)w[utidx+1]==0x91) w[utidx]=161; else // Ñ
-								if ((unsigned char)w[utidx+1]==0xB1) w[utidx]=171; else // ñ
-								if ((unsigned char)w[utidx+1]==0xA7) {                  // ç
+								if ((unsigned char)w[utidx+1]==0xB9) w[utidx]=124; else // ï¿½
+								if ((unsigned char)w[utidx+1]==0xA9) w[utidx]=123; else // ï¿½
+								if ((unsigned char)w[utidx+1]==0xA8) w[utidx]=125; else // ï¿½
+								if ((unsigned char)w[utidx+1]==0xA0) w[utidx]=64; else  // ï¿½
+								if ((unsigned char)w[utidx+1]==0x91) w[utidx]=161; else // ï¿½
+								if ((unsigned char)w[utidx+1]==0xB1) w[utidx]=171; else // ï¿½
+								if ((unsigned char)w[utidx+1]==0xA7) {                  // ï¿½
 									w[utidx]=92;
 									w[utidx+1]=92; // conversion to "\\"
 								} else
@@ -25211,7 +25211,7 @@ int RasmAssembleInfoIntoRAMROM(const char *datain, int lenin, struct s_rasm_info
 
 	ae=PreProcessing(NULL,1,datain,lenin,NULL);
 
-	/* extension 4Mo = 256 slots + 4 slots 64K de RAM par défaut => 260 */
+	/* extension 4Mo = 256 slots + 4 slots 64K de RAM par dï¿½faut => 260 */
 	maxbank=ramsize>>14;
 	for (i=0;i<maxbank;i++) {
 		ramidx=i*16384;
@@ -25244,7 +25244,7 @@ int RasmAssembleInfoIntoRAM(const char *datain, int lenin, struct s_rasm_info **
 
 	ae=PreProcessing(NULL,1,datain,lenin,NULL);
 
-	/* extension 4Mo = 256 slots + 4 slots 64K de RAM par défaut => 260 */
+	/* extension 4Mo = 256 slots + 4 slots 64K de RAM par dï¿½faut => 260 */
 	maxbank=ramsize>>14;
 	for (i=0;i<maxbank;i++) {
 		ramidx=i*16384;
@@ -25293,7 +25293,7 @@ int RasmAssembleInfoParam(const char *datain, int lenin, unsigned char **dataout
 
 #define AUTOTEST_IS_REGISTER "assert is_register('bc')==1 : assert is_register('d')==1 : assert is_register('e')==1 : assert is_register('z')==0 : assert is_register('rr')==0 : nop "
 
-#define AUTOTEST_ACCENT "defb 'grouiké'"
+#define AUTOTEST_ACCENT "defb 'grouikï¿½'"
 
 #define AUTOTEST_QUOTELAST "nop : save'grouik"
 
@@ -25524,7 +25524,7 @@ int RasmAssembleInfoParam(const char *datain, int lenin, unsigned char **dataout
 #define AUTOTEST_DELAYNUM	"macro test  label:    dw {label}:    endm:    repeat 3, idx:idx2 = idx-1:" \
 				" test label_{idx2}:    rend:repeat 3, idx:label_{idx-1}:nop:rend"
 
-#define AUTOTEST_STR		"CHARSET \" !#$%&'()*+,-./0123456789:;<=>?ABCDEFGHIJKLMNOPQRSTUVWXYZ[]^~abcdefghijklmnopqrstuvwxyzéè{}|\",0 : "\
+#define AUTOTEST_STR		"CHARSET \" !#$%&'()*+,-./0123456789:;<=>?ABCDEFGHIJKLMNOPQRSTUVWXYZ[]^~abcdefghijklmnopqrstuvwxyzï¿½ï¿½{}|\",0 : "\
 				"grouik STR 'REGION' : charset : defb 'REGION'"
 
 #define AUTOTEST_STRUCT		"org #1000:label1 :struct male:age    defb 0:height defb 0:endstruct:struct female:" \

--- a/rasm.c
+++ b/rasm.c
@@ -23,7 +23,7 @@ You may send requests/bugs in the same topic
 -----------------------------------------------------------------------------------------------------
 This software is using MIT "expat" license
 
-ï¿½ Copyright ï¿½ BERGE Edouard (roudoudou)
+« Copyright © BERGE Edouard (roudoudou)
 
 Permission  is  hereby  granted,  free  of charge,to any person obtaining a copy  of  this  software
 and  associated  documentation/source   files   of RASM, to deal in the Software without restriction,
@@ -38,7 +38,7 @@ including  but  not  limited  to the warranties of merchantability,   fitness   
 purpose  and  noninfringement.  In  no event shall the  authors  or  copyright  holders be liable for
 any  claim, damages  or other  liability,  whether in  an  action  of  contract, tort  or  otherwise,
 arising from,  out of  or in connection  with  the software  or  the  use  or  other  dealings in the
-Software. ï¿½
+Software. »
 -----------------------------------------------------------------------------------------------------
 Linux compilation with GCC or Clang:
 cc rasm.c -O2 -lm -lrt -march=native -o rasm
@@ -498,7 +498,7 @@ struct s_hfe_action {
 	int ioffset;
 	// deferred calculation info
 	int iw,nbparam;
-	// copie intï¿½grale des paramï¿½tres?
+	// copie intégrale des paramètres?
 	char **param;
 	int iparam,mparam;
 	// extended sector definition
@@ -764,7 +764,7 @@ struct s_rasm_thread {
 /*********************************************************
             S N A P S H O T     E X P O R T
 *********************************************************/
-/* extension 4Mo = 256 slots + 4 slots 64K de RAM par dï¿½faut => 260 */
+/* extension 4Mo = 256 slots + 4 slots 64K de RAM par défaut => 260 */
 
 #define BANK_MAX_NUMBER 260
 
@@ -1356,7 +1356,7 @@ A-Z variable ou fonction (cos, sin, tan, sqr, pow, mod, and, xor, mod, ...)
 +*-/&^m| operateur
 */
 
-#define AutomateExpressionValidCharExtendedDefinition "0123456789.ABCDEFGHIJKLMNOPQRSTUVWXYZ_{}@+-*/~^$#%<=>|&" /* ï¿½ */
+#define AutomateExpressionValidCharExtendedDefinition "0123456789.ABCDEFGHIJKLMNOPQRSTUVWXYZ_{}@+-*/~^$#%<=>|&" /* § */
 #define AutomateExpressionValidCharFirstDefinition "#%0123456789.ABCDEFGHIJKLMNOPQRSTUVWXYZ_@${"
 #define AutomateExpressionValidCharDefinition "0123456789.ABCDEFGHIJKLMNOPQRSTUVWXYZ_{}@$"
 #define AutomateValidLabelFirstDefinition ".ABCDEFGHIJKLMNOPQRSTUVWXYZ_@"
@@ -1419,7 +1419,7 @@ nMaxCompressedSize=65536;
 
 /* RAW */
 nFlags=1<<1; // nFlags=LZSA_FLAG_RAW_BLOCK;
-/* par dï¿½faut du LZSA1-Fast */
+/* par défaut du LZSA1-Fast */
 if (version<1 || version>2) {
 	version=1;
 }
@@ -2092,14 +2092,14 @@ int StringIsMem(char *w)
 					break;
 				case '(':p++;break;
 				case ')':p--;
-					/* si on sort de la premiï¿½re parenthï¿½se */
+					/* si on sort de la première parenthèse */
 					if (!p && w[idx+1]) return 0;
 					break;
 				default:break;
 			}
 			idx++;
 		}
-		/* si on ne termine pas par une parenthï¿½se */
+		/* si on ne termine pas par une parenthèse */
 		if (w[idx-1]!=')') return 0;
 	} else {
 		return 0;
@@ -2717,7 +2717,7 @@ void FreeAssenv(struct s_assenv *ae)
 				debug_symbol.v=ae->label[i].ptr;
 				ObjectArrayAddDynamicValueConcat((void**)&ae->debug.symbol,&ae->debug.nbsymbol,&ae->debug.maxsymbol,&debug_symbol,sizeof(struct s_debug_symbol));
 			} else {
-				/* les labels locaux et gï¿½nï¿½rï¿½s */
+				/* les labels locaux et générés */
 				debug_symbol.name=TxtStrDup(ae->label[i].name);
 				if (ae->label[i].localsize) debug_symbol.name[ae->label[i].localsize]=0;
 				debug_symbol.v=ae->label[i].ptr;
@@ -3236,10 +3236,10 @@ void CheckAndSortAliases(struct s_assenv *ae)
 		}
 	}
 	
-	/* cas particuliers pour insertion en dï¿½but ou fin de liste */
+	/* cas particuliers pour insertion en début ou fin de liste */
 	if (ae->ialias-1) {
 		if (ae->alias[ae->ialias-1].crc>ae->alias[ae->ialias-2].crc) {
-			/* pas de tri il est dï¿½jï¿½ au bon endroit */
+			/* pas de tri il est déjà au bon endroit */
 		} else if (ae->alias[ae->ialias-1].crc<ae->alias[0].crc) {
 			/* insertion tout en bas de liste */
 			tmpalias=ae->alias[ae->ialias-1];
@@ -6065,7 +6065,7 @@ double ComputeExpressionCore(struct s_assenv *ae,char *original_zeexpression,int
 #endif
 						minivarbuffer=TranslateTag(ae,minivarbuffer, &touched,0,E_TAGOPTION_NONE);
 #if TRACE_COMPUTE_EXPRESSION
-	printf("aprï¿½s curly [%s]\n",minivarbuffer);
+	printf("après curly [%s]\n",minivarbuffer);
 #endif
 						ae->computectx=&ae->ctx1;
 						if (!touched) {
@@ -6117,7 +6117,7 @@ double ComputeExpressionCore(struct s_assenv *ae,char *original_zeexpression,int
 						curdic=SearchDico(ae,ae->computectx->varbuffer+minusptr,crc);
 						if (curdic) {
 #if TRACE_COMPUTE_EXPRESSION
-	printf("trouvï¿½ valeur=%.2lf\n",curdic->v);
+	printf("trouvé valeur=%.2lf\n",curdic->v);
 #endif
 							curval=curdic->v;
 							break;
@@ -6129,22 +6129,22 @@ double ComputeExpressionCore(struct s_assenv *ae,char *original_zeexpression,int
 							} else if (strncmp(ae->computectx->varbuffer+minusptr,"{BANK}",6)==0) {
 								bank=6;
 								page=0;
-								/* obligï¿½ de recalculer le CRC */
+								/* obligé de recalculer le CRC */
 								crc=GetCRC(ae->computectx->varbuffer+minusptr+bank);
 							} else if (strncmp(ae->computectx->varbuffer+minusptr,"{PAGE}",6)==0) {
 								bank=6;
 								page=1;
-								/* obligï¿½ de recalculer le CRC */
+								/* obligé de recalculer le CRC */
 								crc=GetCRC(ae->computectx->varbuffer+minusptr+bank);
 							} else if (strncmp(ae->computectx->varbuffer+minusptr,"{PAGESET}",9)==0) {
 								bank=9;
 								page=2;
-								/* obligï¿½ de recalculer le CRC */
+								/* obligé de recalculer le CRC */
 								crc=GetCRC(ae->computectx->varbuffer+minusptr+bank);
 							} else if (strncmp(ae->computectx->varbuffer+minusptr,"{SIZEOF}",8)==0) {
 								bank=8;
 								page=3;
-								/* obligï¿½ de recalculer le CRC */
+								/* obligé de recalculer le CRC */
 								crc=GetCRC(ae->computectx->varbuffer+minusptr+bank);
 								curval=-1;
 								/* search in structures aliases */
@@ -6184,8 +6184,8 @@ double ComputeExpressionCore(struct s_assenv *ae,char *original_zeexpression,int
 							/* limited label translation while processing crunched blocks
 							   ae->curlz == current crunched block processed
 							   expression->crunch_block=0 -> oui
-							   expression->crunch_block=1 -> oui si mï¿½me block
-							   expression->crunch_block=2 -> non car sera relogï¿½e
+							   expression->crunch_block=1 -> oui si même block
+							   expression->crunch_block=2 -> non car sera relogée
 							*/
 							if (page!=3) {
 
@@ -6213,7 +6213,7 @@ if (didx>0 && didx<ae->ie) {
 		curlabel=NULL;
 	}
 
-	/* pas trouvï¿½ on cherche LEGACY */
+	/* pas trouvé on cherche LEGACY */
 	if (!curlabel) {
 		curlabel=SearchLabel(ae,ae->computectx->varbuffer+minusptr+bank,crc);
 #if TRACE_LABEL || TRACE_COMPUTE_EXPRESSION
@@ -6237,7 +6237,7 @@ if (didx>0 && didx<ae->ie) {
 
 		/* on essaie toujours de trouver le label du module courant */	
 		curlabel=SearchLabel(ae,dblvarbuffer,GetCRC(dblvarbuffer));
-		/* pas trouvï¿½ on cherche LEGACY */
+		/* pas trouvé on cherche LEGACY */
 		if (!curlabel) curlabel=SearchLabel(ae,ae->computectx->varbuffer+minusptr+bank,crc);
 #if TRACE_LABEL || TRACE_COMPUTE_EXPRESSION
 		else printf("label trouve via ajout du MODULE\n");
@@ -6247,7 +6247,7 @@ if (didx>0 && didx<ae->ie) {
 	} else {
 		curlabel=SearchLabel(ae,ae->computectx->varbuffer+minusptr+bank,crc);
 #if TRACE_LABEL || TRACE_COMPUTE_EXPRESSION
-		if (curlabel) printf("label trouve sans avoir ajoutï¿½ de MODULE\n");
+		if (curlabel) printf("label trouve sans avoir ajouté de MODULE\n");
 #endif
 	}
 }
@@ -6307,7 +6307,7 @@ printf("page=%d | ptr=%X ibank=%d\n",page,curlabel->ptr,curlabel->ibank);
 										} else {
 											int process_label=1;
 
-											// si on est dans une section crunchï¿½e, on doit faire un contrï¿½le ï¿½tendu du scope du label
+											// si on est dans une section crunchée, on doit faire un contrôle étendu du scope du label
 											if (ae->lzsection[curlabel->lz].lzversion) {
 												/* label MUST be intermediate OR in the crunched block */
 												//if (curlabel->iorgzone==ae->expression[didx].iorgzone) {
@@ -6486,7 +6486,7 @@ printf("stage 2 | page=%d | ptr=%X ibank=%d\n",page,curlabel->ptr,curlabel->iban
 
 										reverse_idx=strlen(ae->computectx->varbuffer)-1;
 										if (ae->computectx->varbuffer[reverse_idx]>='0' && ae->computectx->varbuffer[reverse_idx]<='9') {
-											/* vu que ï¿½a ne PEUT PAS ï¿½tre une valeur litï¿½rale, on ne fait pas de test de dï¿½bordement */
+											/* vu que ça ne PEUT PAS être une valeur litérale, on ne fait pas de test de débordement */
 											reverse_idx--;
 											while (ae->computectx->varbuffer[reverse_idx]>='0' && ae->computectx->varbuffer[reverse_idx]<='9') {
 												reverse_idx--;
@@ -7360,7 +7360,7 @@ double ComputeExpression(struct s_assenv *ae,char *expr, int ptr, int didx, int 
 printf("MakeAlias (1) EXPR=[%s EQU %s]\n",expr,ptr_exp2);
 #endif
 			
-			/* alias locaux ou de proximitï¿½ */
+			/* alias locaux ou de proximité */
 			if (strchr("@.",expr[0])) {
 #if TRACE_COMPUTE_EXPRESSION
 printf("WARNING! alias is local! [%s]\n",expr);
@@ -7810,7 +7810,7 @@ printf("ExpressionFastTranslate (full) -> replace var (%s=%0.1lf)\n",varbuffer,v
 					}
 				}
 			}
-			/* on cherche aussi dans les labels existants => prioritï¿½ aux modules!!! */   // modulmodif => pas utile?
+			/* on cherche aussi dans les labels existants => priorité aux modules!!! */   // modulmodif => pas utile?
 			if (!found_replace) {
 				curlabel=SearchLabel(ae,varbuffer,crc);
 				if (curlabel) {
@@ -8014,7 +8014,7 @@ printf("exprout=[%s]\n",expr);
 								}
 							} else if (ae->forcesnapshot) {
 								if (ae->activebank<BANK_MAX_NUMBER) {
-									/* on autorise le prï¿½fixe BANK en snapshot avec une subtilitï¿½ */
+									/* on autorise le préfixe BANK en snapshot avec une subtilité */
 								if (ae->bankset[ae->activebank>>2]) {
 									tagvalue=ae->activebank+(ae->codeadr>>14); /* dans un bankset on tient compte de l'adresse */
 								} else {
@@ -8186,7 +8186,7 @@ void PushExpression(struct s_assenv *ae,int iw,enum e_expression zetype)
 				case E_EXPRESSION_BRS:break;
 				default:break;
 			}
-			/* hack pourri pour gï¿½rer le $ */
+			/* hack pourri pour gérer le $ */
 			ae->codeadr+=startptr;
 			/* ok mais les labels locaux des macros? */
 
@@ -8535,7 +8535,7 @@ void EDSK_load(struct s_assenv *ae,struct s_edsk_wrapper *curwrap, char *edskfil
 					FreeAssenv(ae);exit(ABORT_ERROR);
 				}
 			}
-			/* piste ï¿½ piste on lit les blocs DANS L'ORDRE LOGIQUE!!! */
+			/* piste à piste on lit les blocs DANS L'ORDRE LOGIQUE!!! */
 			for (b=0xC1;b<=0xC9;b++)
 			for (s=0;s<sectornumber;s++) {
 				if (data[i+24+8*s+2]==b) {
@@ -8632,7 +8632,7 @@ void EDSK_load(struct s_assenv *ae,struct s_edsk_wrapper *curwrap, char *edskfil
 	printf("\n");
 #endif
 
-				/* piste ï¿½ piste on lit les blocs DANS L'ORDRE LOGIQUE!!! */
+				/* piste à piste on lit les blocs DANS L'ORDRE LOGIQUE!!! */
 				for (b=0xC1;b<=0xC9;b++) {
 					tmpcurrentsectorposition=currentsectorposition;
 					for (s=0;s<sectornumber;s++) {
@@ -8661,7 +8661,7 @@ void EDSK_load(struct s_assenv *ae,struct s_edsk_wrapper *curwrap, char *edskfil
 	/* Rasm management of (e)DSK files is AMSDOS compatible, just need to copy CATalog blocks but sort them... */
 	memcpy(&curwrap->entry[0],curwrap->blocks[0],1024);
 	memcpy(&curwrap->entry[32],curwrap->blocks[1],1024);
-	/* tri des entrï¿½es selon le user */
+	/* tri des entrées selon le user */
 	qsort(curwrap->entry,64,sizeof(struct s_edsk_wrapper_entry),cmpAmsdosentry);
 	curwrap->nbentry=64;
 	for (i=0;i<64;i++) {
@@ -8948,10 +8948,10 @@ void EDSK_write_file(struct s_assenv *ae,struct s_edsk_wrapper *faceA,struct s_e
 	
 	if (!faceA && !faceB) return;
 	
-	/* crï¿½ation des deux blocs du directory par face */
+	/* création des deux blocs du directory par face */
 	EDSK_build_amsdos_directory(faceA);
 	EDSK_build_amsdos_directory(faceB);
-	/* ï¿½criture header */
+	/* écriture header */
 	strcpy((char *)header,"EXTENDED CPC DSK File\r\nDisk-Info\r\n");
 	sprintf(headertag,"%-9.9s",RASM_SNAP_VERSION);
 	strcpy((char *)header+0x22,headertag);
@@ -8972,7 +8972,7 @@ void EDSK_write_file(struct s_assenv *ae,struct s_edsk_wrapper *faceA,struct s_e
 #endif
 	FileWriteBinary(faceA->edsk_filename,(char *)header,256);
 	
-	/* ï¿½criture des pistes */
+	/* écriture des pistes */
 	for (t=0;t<40;t++) {
 		strcpy((char *)trackblock,"Track-Info\r\n");
 		trackblock[0x10]=t;
@@ -9013,15 +9013,15 @@ void EDSK_write_file(struct s_assenv *ae,struct s_edsk_wrapper *faceA,struct s_e
 #if TRACE_EDSK
 	if (t<3) printf("\n"); else if (t==3) printf("...\n");
 #endif
-		/* ï¿½criture du track info */
+		/* écriture du track info */
 		FileWriteBinary(faceA->edsk_filename,(char *)trackblock,256);
 
 
-		/* il faut convertir les blocs logiques en secteurs physiques ET entrelacï¿½s */
+		/* il faut convertir les blocs logiques en secteurs physiques ET entrelacés */
 		idblock=t*9/2;
 		blockoffset=((t*9)%2)*512;
 
-		/* le premier secteur de la piste est ï¿½ cheval sur le bloc logique une fois sur deux */
+		/* le premier secteur de la piste est à cheval sur le bloc logique une fois sur deux */
 		FileWriteBinary(faceA->edsk_filename,(char *)&faceA->blocks[idblock][0]+blockoffset,512); /* C1 */
 		if (!blockoffset) {
 			FileWriteBinary(faceA->edsk_filename,(char *)&faceA->blocks[idblock+2][0]+512,512); /* C6 */
@@ -9043,7 +9043,7 @@ void EDSK_write_file(struct s_assenv *ae,struct s_edsk_wrapper *faceA,struct s_e
 			FileWriteBinary(faceA->edsk_filename,(char *)&faceA->blocks[idblock+2][0]+512,512); /* C5 */
 		}
 
-		/* @@TODO ï¿½a semble un peu foireux comme procï¿½dï¿½ */	
+		/* @@TODO ça semble un peu foireux comme procédé */	
 		if (faceB) {
 #if TRACE_EDSK
 	printf("writing EDSK face B /!\\  probably NOT WORKING !!!\n");
@@ -9053,9 +9053,9 @@ void EDSK_write_file(struct s_assenv *ae,struct s_edsk_wrapper *faceA,struct s_e
 				trackblock[0x18+i*8+0]=trackblock[0x10];
 				trackblock[0x18+i*8+1]=trackblock[0x11];
 			}
-			/* ï¿½criture du track info */
+			/* écriture du track info */
 			FileWriteBinary(faceB->edsk_filename,(char *)trackblock,256);
-			/* ï¿½criture des secteurs */
+			/* écriture des secteurs */
 			idblock=t*9/2;
 			blockoffset=((t*9)%2)*512;
 			FileWriteBinary(faceB->edsk_filename,(char *)&faceB->blocks[idblock][0]+blockoffset,512);
@@ -9303,7 +9303,7 @@ void PopAllSave(struct s_assenv *ae)
 		/* DSK management */
 		if (ae->save[is].dsk) {
 			if (ae->save[is].iwdskname!=-1) {
-				/* obligï¿½ de dupliquer ï¿½ cause du reuse */
+				/* obligé de dupliquer à cause du reuse */
 				dskfilename=TxtStrDup(ae->wl[ae->save[is].iwdskname].w);
 				dskfilename[strlen(dskfilename)-1]=0;
 				if (!EDSK_addfile(ae,dskfilename+1,ae->save[is].face,filename,ae->mem[ae->save[is].ibank]+offset,size,offset,run)) {
@@ -9372,7 +9372,7 @@ void PopAllExpression(struct s_assenv *ae, int crunched_zone)
 
 	   idealement on doit tolerer les adresses situees apres le crunch dans une autre ORG zone!
 
-	   on utilise ae->stage pour crï¿½er un ï¿½tat intermï¿½diaire dans le ComputeExpressionCore
+	   on utilise ae->stage pour créer un état intermédiaire dans le ComputeExpressionCore
 	*/
 	if (crunched_zone>=0) {
 		ae->stage=1;
@@ -9834,7 +9834,7 @@ printf("PUSH Orphan PROXIMITY label that cannot be exported [%s]->[%s]\n",ae->wl
 	else printf("PUSH => NO MODULE for local label\n");
 #endif
 
-			/* contrï¿½le dico uniquement avec des labels non locaux */
+			/* contrôle dico uniquement avec des labels non locaux */
 			if (SearchDico(ae,curlabel.name,curlabel.crc)) {
 				MakeError(ae,ae->idx,GetCurrentFile(ae),ae->wl[ae->idx].l,"cannot create label [%s] as there is already a variable with the same name\n",curlabel.name);
 				return;
@@ -12627,9 +12627,9 @@ void _DEFF_struct(struct s_assenv *ae) {
 			ae->idx++;
 			/* conversion des symboles connus */
 			ExpressionFastTranslate(ae,&ae->wl[ae->idx].w,0);
-			/* calcul de la valeur dï¿½finitive de l'expression */
+			/* calcul de la valeur définitive de l'expression */
 			v=ComputeExpressionCore(ae,ae->wl[ae->idx].w,ae->outputadr,0);
-			/* conversion en rï¿½el Amsdos */
+			/* conversion en réel Amsdos */
 			rc=__internal_MakeRosoftREAL(ae,v,0);
 			___output(ae,rc[0]);___output(ae,rc[1]);___output(ae,rc[2]);___output(ae,rc[3]);___output(ae,rc[4]);			
 		} while (ae->wl[ae->idx].t==0);
@@ -12665,9 +12665,9 @@ void _DEFR_struct(struct s_assenv *ae) {
 			ae->idx++;
 			/* conversion des symboles connus */
 			ExpressionFastTranslate(ae,&ae->wl[ae->idx].w,0);
-			/* calcul de la valeur dï¿½finitive de l'expression */
+			/* calcul de la valeur définitive de l'expression */
 			v=ComputeExpressionCore(ae,ae->wl[ae->idx].w,ae->outputadr,0);
-			/* conversion en rï¿½el Amsdos */
+			/* conversion en réel Amsdos */
 			rc=__internal_MakeAmsdosREAL(ae,v,0);
 			___output(ae,rc[0]);___output(ae,rc[1]);___output(ae,rc[2]);___output(ae,rc[3]);___output(ae,rc[4]);			
 		} while (ae->wl[ae->idx].t==0);
@@ -13068,7 +13068,7 @@ void __hfe_init(struct s_assenv *ae, struct s_hfe_action *hfe_action) {
 	struct s_hfe_floppy hfeflop={0};
 	ae->hfeside=0;
 	ae->hfetrack=0;
-	// remplir une struct HFE par dï¿½faut
+	// remplir une struct HFE par défaut
 	ObjectArrayAddDynamicValueConcat((void **)&ae->hfedisk,&ae->nbhfedisk,&ae->maxhfedisk,&hfeflop,sizeof(hfeflop));
 	ae->hfedisk[ae->nbhfedisk-1].filename=hfe_action->filename;
 	// current pointer
@@ -13268,7 +13268,7 @@ void __hfe_add_sector(struct s_assenv *ae, struct s_hfe_action *hfe_action) {
 	zebyte=crc&0xFF; // CRC low weight
 	ObjectArrayAddDynamicValueConcat((void **)&ae->hfe->data,&ae->hfe->idata,&ae->hfe->mdata,&zebyte,sizeof(zebyte));
 
-	// gestion des longueurs ï¿½ la con
+	// gestion des longueurs à la con
 	switch (sectorsize) {
 		case 0:curlen=128;break;
 		case 1:curlen=256;break;
@@ -13591,7 +13591,7 @@ struct s_edsk_global_struct *edsktool_NewEDSK(char *format) {
         return edsk;
 }
 
-struct s_edsk_global_struct *edsktool_EDSK_load(char *edskfilename) //@@TODO faire un mï¿½canisme de cache
+struct s_edsk_global_struct *edsktool_EDSK_load(char *edskfilename) //@@TODO faire un mécanisme de cache
 {
         #undef FUNC
         #define FUNC "EDSK_load"
@@ -13823,7 +13823,7 @@ void edsktool_EDSK_write_file(struct s_edsk_global_struct *edsk, char *output_fi
 
 	FileRemoveIfExists(output_filename);
 
-        /* ï¿½criture header */
+        /* écriture header */
         strcpy((char *)header,"EXTENDED CPC DSK File\r\nDisk-Info\r\n");
         sprintf(headertag,"%-9.9s","edskt");
         strcpy((char *)header+0x22,headertag);
@@ -13847,7 +13847,7 @@ void edsktool_EDSK_write_file(struct s_edsk_global_struct *edsk, char *output_fi
 
 	FileWriteBinary(output_filename,(char*)header,256);
 
-        /* ï¿½criture des pistes */
+        /* écriture des pistes */
         for (t=0;t<edsk->tracknumber;t++)
         for (face=0;face<edsk->sidenumber;face++) {
                 curtrack=t*edsk->sidenumber+face;
@@ -14822,7 +14822,7 @@ void __EDSK(struct s_assenv *ae) {
 		// which action?
 		switch (ae->wl[ae->idx+1].w[0]) {
 			case 'A':if (strcmp(ae->wl[ae->idx+1].w,"ADD")==0)	curaction.action=E_EDSK_ACTION_ADD; else cmderr=1;break; // add sector
-			case 'C':if (strcmp(ae->wl[ae->idx+1].w,"CREATE")==0)	curaction.action=E_EDSK_ACTION_CREATE; else cmderr=1;break; // nombre de pistes + format ï¿½ventuel
+			case 'C':if (strcmp(ae->wl[ae->idx+1].w,"CREATE")==0)	curaction.action=E_EDSK_ACTION_CREATE; else cmderr=1;break; // nombre de pistes + format éventuel
 			case 'D':if (strcmp(ae->wl[ae->idx+1].w,"DROP")==0)	curaction.action=E_EDSK_ACTION_DROP; else cmderr=1;break; // drop track or sector
 			case 'G':if (strcmp(ae->wl[ae->idx+1].w,"GAPFIX")==0)	curaction.action=E_EDSK_ACTION_GAPFIX; else cmderr=1;break; // fix GAP to fit an ideal track
 			case 'M':if (strcmp(ae->wl[ae->idx+1].w,"MERGE")==0)	curaction.action=E_EDSK_ACTION_MERGE; else // merge edsk
@@ -14876,7 +14876,7 @@ void __EDSK(struct s_assenv *ae) {
 		/*
 		cursave.ioffset=ae->idx+2;
 		cursave.isize=ae->idx+3;
-		ExpressionFastTranslate(ae,&ae->wl[ae->idx+2].w,1); // si on utilise des variables ï¿½a ï¿½vite la grouille post traitement...
+		ExpressionFastTranslate(ae,&ae->wl[ae->idx+2].w,1); // si on utilise des variables ça évite la grouille post traitement...
 		ExpressionFastTranslate(ae,&ae->wl[ae->idx+3].w,1); // idem
 		*/
 
@@ -16069,7 +16069,7 @@ void __LOCALISATION(struct s_assenv *ae) {
 			mloc.logical=RoundComputeExpression(ae,ae->wl[ae->idx+2].w,ae->codeadr,0,0);
 		}
 		mloc.physical=ae->activebank;
-		ae->remu=1; // si c'est pas fait, on force :)
+		//ae->remu=1; // si c'est pas fait, on force :)
 		ObjectArrayAddDynamicValueConcat((void**)&ae->memory_localisation,&ae->imemory_localisation,&ae->mmemory_localisation,&mloc,sizeof(struct s_memory_localisation));
 	} else {
 		MakeError(ae,ae->idx,GetCurrentFile(ae),ae->wl[ae->idx].l,"Usage is: LOCALISATION [RAM|ROM],[16K page number|LOWER]\n");
@@ -16229,7 +16229,7 @@ void __BANKSET(struct s_assenv *ae) {
 		ae->orgzone[ae->io-1].memend=ae->outputadr;
 	}
 	ae->bankmode=1;
-	//ae->remu=1; // I guess there is no reason to force it here. Otherwise standard ACE chuncks are not generated
+	//ae->remu=1;
 	
 	if (ae->wl[ae->idx+1].t!=2) {
 		ExpressionFastTranslate(ae,&ae->wl[ae->idx+1].w,0);
@@ -16565,7 +16565,7 @@ void __MACRO(struct s_assenv *ae) {
 			MakeError(ae,ae->idx,GetCurrentFile(ae),ae->wl[ae->idx].l,"Macro was not closed\n");
 		}
 		ObjectArrayAddDynamicValueConcat((void**)&ae->macro,&ae->imacro,&ae->mmacro,&curmacro,sizeof(curmacro));
-		/* le quicksort n'est pas optimal mais on n'est pas supposï¿½ en crï¿½er des milliers */
+		/* le quicksort n'est pas optimal mais on n'est pas supposé en créer des milliers */
 		qsort(ae->macro,ae->imacro,sizeof(struct s_macro),cmpmacros);
 
 		/* ajustement des mots lus */
@@ -16729,7 +16729,7 @@ struct s_wordlist *__MACRO_EXECUTE(struct s_assenv *ae, int imacro) {
 				ae->nbword+=ae->macro[imacro].nbword-1-nbparam-reload;
 				ae->wl=MemRealloc(ae->wl,ae->nbword*sizeof(struct s_wordlist));
 			} else {
-				/* si on rï¿½duit pas de realloc pour ne pas perdre de donnees */
+				/* si on réduit pas de realloc pour ne pas perdre de donnees */
 				ae->nbword+=ae->macro[imacro].nbword-1-nbparam-reload;
 			}
 			iline=ae->wl[ae->idx].l;
@@ -17666,7 +17666,7 @@ void __WHILE(struct s_assenv *ae) {
 			whilewend.maxim=ae->imacropos;
 			whilewend.while_counter=1;
 			ae->whilecounter++;
-			/* pour gï¿½rer les macros situï¿½s dans le while prï¿½cedent aprï¿½s un repeat/while courant */
+			/* pour gérer les macros situés dans le while précedent après un repeat/while courant */
 			if (ae->iw) whilewend.maxim=ae->whilewend[ae->iw-1].maxim;
 			if (ae->ir && ae->repeat[ae->ir-1].maxim>whilewend.maxim) whilewend.maxim=ae->repeat[ae->ir-1].maxim;
 			ObjectArrayAddDynamicValueConcat((void**)&ae->whilewend,&ae->iw,&ae->mw,&whilewend,sizeof(whilewend));
@@ -17775,7 +17775,7 @@ void __REPEAT(struct s_assenv *ae) {
 				if ((rvar=SearchDico(ae,ae->wl[ae->idx].w,crc))!=NULL) {
 					rvar->v=vstart;
 				} else {
-					/* mais ne peut ï¿½tre un label ou un alias */
+					/* mais ne peut être un label ou un alias */
 					ExpressionSetDicoVar(ae,ae->wl[ae->idx].w,vstart,0);
 					rvar=SearchDico(ae,ae->wl[ae->idx].w,crc);
 				}
@@ -17799,7 +17799,7 @@ void __REPEAT(struct s_assenv *ae) {
 		currepeat.value=ae->repeatcounter;
 		currepeat.repeat_counter=1;
 		ae->repeatcounter++;
-		/* pour gï¿½rer les macros situï¿½s dans le repeat prï¿½cedent aprï¿½s le repeat courant */
+		/* pour gérer les macros situés dans le repeat précedent après le repeat courant */
 		if (ae->ir) currepeat.maxim=ae->repeat[ae->ir-1].maxim;
 		if (ae->iw && ae->whilewend[ae->iw-1].maxim>currepeat.maxim) currepeat.maxim=ae->whilewend[ae->iw-1].maxim;
 		if (ae->imacropos>currepeat.maxim) currepeat.maxim=ae->imacropos;
@@ -18427,7 +18427,7 @@ void ___org_new(struct s_assenv *ae, int nocode) {
 	
 	/* check current ORG request */
 	for (i=0;i<ae->io;i++) {
-		/* aucun contrï¿½le sur les ORG non ï¿½crits ou en NOCODE */
+		/* aucun contrôle sur les ORG non écrits ou en NOCODE */
 		if (ae->orgzone[i].memstart!=ae->orgzone[i].memend && !ae->orgzone[i].nocode) {
 			if (ae->orgzone[i].ibank==ae->activebank) {
 				if (ae->outputadr<ae->orgzone[i].memend && ae->outputadr>=ae->orgzone[i].memstart) {
@@ -18731,11 +18731,11 @@ printf("pushLight [%s] %d:%X\n",curlabel.name,curlabel.ibank,curlabel.ptr);
 #if TRACE_STRUCT
 printf("struct new behaviour (scan for %d fields)\n",ae->rasmstruct[irs].irasmstructfield);
 #endif
-				/* dï¿½terminer si on est en remplissage par dï¿½faut ou remplissage surchargï¿½ */
+				/* déterminer si on est en remplissage par défaut ou remplissage surchargé */
 				for (i=0;i<ae->rasmstruct[irs].irasmstructfield;i++) {
 
 					if (!ae->wl[ae->idx+2+i].t || i+1>=ae->rasmstruct[irs].irasmstructfield) {
-						/* si le champ est sur le mï¿½me offset que le prï¿½cï¿½dent, on le saute */
+						/* si le champ est sur le même offset que le précédent, on le saute */
 						if (i && ae->rasmstruct[irs].rasmstructfield[i].offset>ae->rasmstruct[irs].rasmstructfield[i-1].offset) continue;
 
 #if TRACE_STRUCT
@@ -18765,7 +18765,7 @@ printf("*break*\n");
 				}
 #endif
 
-				/* (LEGACY) filler, on balance des zï¿½ros en attendant d'avoir la complï¿½tion par init */
+				/* (LEGACY) filler, on balance des zéros en attendant d'avoir la complétion par init */
 #if TRACE_STRUCT
 printf("struct (almost) legacy filler from %d to %d-1\n",localsize,ae->rasmstruct[irs].size);
 #endif
@@ -18800,7 +18800,7 @@ printf("struct (almost) legacy filler from %d to %d-1\n",localsize,ae->rasmstruc
 #if 0
 				for (i=localsize;i<ae->rasmstruct[irs].size;i++) ___output(ae,0);
 #endif
-				ae->idx+=2; // probablement ï¿½ revoir dans le cas d'une init!!!
+				ae->idx+=2; // probablement à revoir dans le cas d'une init!!!
 			}
 		}
 	} else {
@@ -19128,11 +19128,11 @@ printf("AudioLoadSample filesize=%d st=%d normalize=%.2lf\n",filesize,sample_typ
 		
 		idx=subchunk-data;
 	} else {
-		// lecture brute du fichier car il ne ressemble pas ï¿½ un WAV :)
+		// lecture brute du fichier car il ne ressemble pas à un WAV :)
 		idx=0;
 		nbchannel=1;
 		nbsample=filesize;
-		_internal_getsample=__internal_getsample8; // 8 bits signï¿½s
+		_internal_getsample=__internal_getsample8; // 8 bits signés
 	}
 
 	switch (sample_type) {
@@ -19155,7 +19155,7 @@ printf("AudioLoadSample filesize=%d st=%d normalize=%.2lf\n",filesize,sample_typ
 			}
 			break;
 		case AUDIOSAMPLE_SM2:
-			/* +1 pour ï¿½viter le segfault */
+			/* +1 pour éviter le segfault */
 			for (i=0;i<nbsample+1;i+=2) {
 				for (j=0;j<2;j++) {
 					/* downmixing */
@@ -19182,7 +19182,7 @@ printf("AudioLoadSample filesize=%d st=%d normalize=%.2lf\n",filesize,sample_typ
 				  10 -> 14 // 3/4
 				  11 -> 15 // 4/4			
 			***/
-			/* +3 pour ï¿½viter le segfault */
+			/* +3 pour éviter le segfault */
 			for (i=0;i<nbsample+3;i+=4) {
 				for (j=0;j<4;j++) {
 					/* downmixing */
@@ -19283,7 +19283,7 @@ fprintf(stderr,"no AP-Ultra support in this version!\n");
 #endif
 
 /*
-	meta fonction qui gï¿½re le INCBIN standard plus les variantes SMP et DMA
+	meta fonction qui gère le INCBIN standard plus les variantes SMP et DMA
 */
 void __READ(struct s_assenv *ae) {
 	if (!ae->wl[ae->idx].t) {
@@ -19461,7 +19461,7 @@ printf(" -> VTILES loading\n");
 									if ((rvar=SearchDico(ae,ae->wl[ae->idx+6].w,crc))!=NULL) {
 										rvar->v=ae->hexbin[hbinidx].rawlen;
 									} else {
-										/* mais ne peut ï¿½tre un label ou un alias */
+										/* mais ne peut être un label ou un alias */
 										ExpressionSetDicoVar(ae,ae->wl[ae->idx+6].w,ae->hexbin[hbinidx].rawlen,0);
 									}
 									ae->idx+=6;
@@ -19501,7 +19501,7 @@ printf("we look for tags in the name of a file which were not found\n");
 			for (lm=touched=0;newfilename[lm];lm++) {
 				if (newfilename[lm]=='{') touched++; else if (newfilename[lm]=='}') touched--; else if (touched) newfilename[lm]=toupper(newfilename[lm]);
 			}
-			/* on essaie d'interprï¿½ter le nom du fichier en dynamique */
+			/* on essaie d'interpréter le nom du fichier en dynamique */
 			newfilename=TranslateTag(ae,newfilename,&touched,1,E_TAGOPTION_REMOVESPACE);
 
 			/* Where is the file to load? */
@@ -19630,7 +19630,7 @@ printf("Hexbin -> %s\n",ae->wl[ae->idx+2].w);
 				/* pre-parametres OK (longueur+IDX struct) */
 				if (size<0) {
 #if TRACE_HEXBIN
-printf("taille nï¿½gative %d -> conversion en %d\n",size,ae->hexbin[hbinidx].datalen+size);
+printf("taille négative %d -> conversion en %d\n",size,ae->hexbin[hbinidx].datalen+size);
 #endif
 					size=ae->hexbin[hbinidx].datalen+size;
 					if (size<1) {
@@ -19640,7 +19640,7 @@ printf("taille nï¿½gative %d -> conversion en %d\n",size,ae->hexbin[hbinidx].dat
 				/* negative offset conversion */
 				if (offset<0) {
 #if TRACE_HEXBIN
-printf("offset nï¿½gatif %d -> conversion en %d\n",offset,ae->hexbin[hbinidx].datalen+offset);
+printf("offset négatif %d -> conversion en %d\n",offset,ae->hexbin[hbinidx].datalen+offset);
 #endif
 					offset=ae->hexbin[hbinidx].datalen+offset;
 				}
@@ -19665,7 +19665,7 @@ printf("taille nulle et offset=%d -> conversion en %d\n",offset,size);
 						int outputidx=0;
 						outputdata=MemMalloc(ae->hexbin[hbinidx].datalen);
 #if TRACE_HEXBIN
-printf("output fictif pour rï¿½organiser les donnï¿½es\n");
+printf("output fictif pour réorganiser les données\n");
 #endif
 
 						if (revert) {
@@ -19946,7 +19946,7 @@ void __SAVE(struct s_assenv *ae) {
 				if (!ae->wl[ae->idx+2].t && ae->wl[ae->idx+3].t!=2) {
 					cursave.ibank=ae->activebank;
 					cursave.ioffset=ae->idx+2;
-					ExpressionFastTranslate(ae,&ae->wl[ae->idx+2].w,1); // si on utilise des variables ï¿½a ï¿½vite la grouille post traitement...
+					ExpressionFastTranslate(ae,&ae->wl[ae->idx+2].w,1); // si on utilise des variables ça évite la grouille post traitement...
 					cursave.isize=ae->idx+3;
 					ExpressionFastTranslate(ae,&ae->wl[ae->idx+3].w,1); // idem
 					if (!touched) cursave.iw=ae->idx+1; else cursave.filename=filename;
@@ -21445,7 +21445,7 @@ int Assemble(struct s_assenv *ae, unsigned char **dataout, int *lenout, struct s
 #endif
 
 		for (i=0;i<ae->ilz;i++) {
-			/* on dï¿½pile les symboles dans l'ordre mais on ne reloge pas sur les zones intermï¿½diaires ou post-crunched */
+			/* on dépile les symboles dans l'ordre mais on ne reloge pas sur les zones intermédiaires ou post-crunched */
 			if (ae->lzsection[i].lzversion!=0) {
 				if (ae->lzsection[i].memend==-1) {
 					/* patch idx */
@@ -21772,7 +21772,7 @@ int Assemble(struct s_assenv *ae, unsigned char **dataout, int *lenout, struct s
 		
 		/* enregistrement des fichiers programmes par la directive SAVE */
 		PopAllSave(ae);
-		/* exï¿½cution des actions programmï¿½es par la directive EDSK */
+		/* exécution des actions programmées par la directive EDSK */
 		PopAllEDSK(ae);
 		PopAllHFE(ae);
 
@@ -22286,7 +22286,7 @@ int Assemble(struct s_assenv *ae, unsigned char **dataout, int *lenout, struct s
 									break;
 								}
 							} else {
-								/* compression par dï¿½faut avec snapshot v3 */
+								/* compression par défaut avec snapshot v3 */
 								rlebank=EncodeSnapshotRLE(packed,&ChunkSize,65536);
 								
 								if (bankset>=0 && bankset<=8) {
@@ -22569,7 +22569,7 @@ int Assemble(struct s_assenv *ae, unsigned char **dataout, int *lenout, struct s
 				}
 				FileRemoveIfExists(TMP_filename);
 
-				/* en mode binaire classique on va recherche le dernier espace mï¿½moire dans lequel on a travaillï¿½ qui n'est pas en 'nocode' */
+				/* en mode binaire classique on va recherche le dernier espace mémoire dans lequel on a travaillé qui n'est pas en 'nocode' */
 				for (i=0;i<ae->io;i++) {
 					/* uniquement si le ORG a ete suivi d'ecriture */
 					if (ae->orgzone[i].memstart!=ae->orgzone[i].memend && ae->orgzone[i].nocode!=1) {
@@ -23436,7 +23436,7 @@ void EarlyPrepSrc(struct s_assenv *ae, char **listing, char *filename) {
 			}
 
 			if (listing[l][idx]=='\\') {
-				/* fusion avec la ligne suivante qui est obligatoirement prï¿½sente */
+				/* fusion avec la ligne suivante qui est obligatoirement présente */
 				listing[l]=MemRealloc(listing[l],strlen(listing[l])+strlen(listing[l+1])+1);
 				strcpy(listing[l]+idx,listing[l+1]);
 				strcpy(listing[l+1],"");
@@ -23833,7 +23833,7 @@ printf("nbbank=%d initialised\n",ae->nbbank);
 	} else {
 		ae->outputfilename=TxtStrDup("rasmoutput");
 	}
-	/* si on est en ligne de commande ET que le fichier n'est pas trouvï¿½ */
+	/* si on est en ligne de commande ET que le fichier n'est pas trouvé */
 	if (param && param->filename && !FileExists(param->filename)) {
 		char *LTryExtension[]={".asm",".z80",".inc",".src",".dam",".mxm",".txt",
 					".ASM",".Z80",".INC",".SRC",".DAM",".MXM",".TXT",".o",".s",".O",".S","",NULL};
@@ -23936,7 +23936,7 @@ printf("nbbank=%d initialised\n",ae->nbbank);
 	Automate[',']=2;
 	Automate['\t']=2;
 	/* end of line */
-	Automate[':']=3; /* les 0x0A et 0x0D seront dejaï¿½ remplaces en ':' */
+	Automate[':']=3; /* les 0x0A et 0x0D seront deja  remplaces en ':' */
 	/* expression */
 	Automate['=']=4; /* on stocke l'emplacement de l'egalite */
 	Automate['<']=4; /* ou des operateurs */
@@ -23967,7 +23967,7 @@ printf("read file/flux\n");
 		int flux_nblines=0;
 		int flux_curpos;
 
-		/* copie des donnï¿½es */
+		/* copie des données */
 		for (i=0;i<datalen;i++) {
 			if (datain[i]=='\n') flux_nblines++;
 		}
@@ -23980,7 +23980,7 @@ printf("read file/flux\n");
 				zelines[flux_nblines]=MemMalloc(i-flux_curpos+2);
 				/* copy data+CR */
 				memcpy(zelines[flux_nblines],datain+flux_curpos,i-flux_curpos+1);
-				/* et on ajoute un petit zï¿½ro ï¿½ la fin! */
+				/* et on ajoute un petit zéro à la fin! */
 				zelines[flux_nblines][i-flux_curpos+1]=0;
 #if 0
 if (flux_nblines<50) printf("%02d[%s]\n",flux_nblines,zelines[flux_nblines]);
@@ -24240,7 +24240,7 @@ if (!idx) printf("[%s]\n",listing[l].listing);
 								ae->rawfile[ae->ifile-1]=ae->source_bigbuffer;
 								ae->rawlen[ae->ifile-1]=ae->source_bigbuffer_len;
 							}
-							/* virer les commentaires + prï¿½-traitement */
+							/* virer les commentaires + pré-traitement */
 							EarlyPrepSrc(ae,listing_include,ae->filename[ae->ifile-1]);
 
 							/* split de la ligne en cours + suppression de l'instruction include */
@@ -24425,7 +24425,7 @@ if (!idx) printf("[%s]\n",listing[l].listing);
 						break;
 
 					case 'U':
-						/* code dupliquï¿½ du REND */
+						/* code dupliqué du REND */
 						if (strcmp(bval,"UNTIL")==0) {
 							/* retrouver la structure repeat_index correspondant a l'ouverture */
 							for (ri=nri-1;ri>=0;ri--) {
@@ -24452,7 +24452,7 @@ if (!idx) printf("[%s]\n",listing[l].listing);
 							if (c==quote_type) {
 								waiting_quote=2;
 							}
-						/* code dupliquï¿½ du UNTIL */
+						/* code dupliqué du UNTIL */
 						} else if (strcmp(bval,"REND")==0) {
 							/* retrouver la structure repeat_index correspondant a l'ouverture */
 							for (ri=nri-1;ri>=0;ri--) {
@@ -24599,7 +24599,7 @@ printf("c='%c' automate[c]=%d\n",c>31?c:'.',Automate[((int)c)&0xFF]);
 #if TRACE_PREPRO
 printf("quote\n");
 #endif
-						/* on finalise le mot si on est en dï¿½but d'une nouvelle instruction ET que c'est un SAVE */
+						/* on finalise le mot si on est en début d'une nouvelle instruction ET que c'est un SAVE */
 						if (strcmp(w,"SAVE")==0) {
 							// on ne break pas pour passer dans le case 2 (separator)
 							idx--;
@@ -24614,7 +24614,7 @@ printf("quote\n");
 #if TRACE_PREPRO
 printf("quote\n");
 #endif
-						/* on finalise le mot si on est en dï¿½but d'une nouvelle instruction ET que c'est un SAVE */
+						/* on finalise le mot si on est en début d'une nouvelle instruction ET que c'est un SAVE */
 						if (strcmp(w,"SAVE")==0) {
 							// on ne break pas pour passer dans le case 2 (separator)
 							idx--;
@@ -24666,7 +24666,7 @@ printf("conversion OR vers |\n");
 printf("*** separator='%c'\n",c);
 #endif
 					
-					/* patch argument suit une expression d'ï¿½valuation (ASSERT) */
+					/* patch argument suit une expression d'évaluation (ASSERT) */
 					if (c==',') hadcomma=1;
 					
 					if (lw) {
@@ -24687,7 +24687,7 @@ printf("2/2 Winape maxam operator test for expression [%s]\n",w+ispace);
 							} else {
 								wtmp=TxtStrDup(w);
 							}
-							/* on concatï¿½ne le nouveau mot ï¿½ l'expression */
+							/* on concatène le nouveau mot à l'expression */
 							nbword--;
 							lw=0;
 							for (li=0;wordlist[nbword].w[li];li++) {
@@ -24820,7 +24820,7 @@ printf("EOL\n");
 					Automate['\t']=2;
 					ispace=0;
 					texpr=0;
-					/* si le mot lu a plus d'un caractï¿½re */
+					/* si le mot lu a plus d'un caractère */
 					if (lw) {
 						if (!wordlist[nbword-1].t && (wordlist[nbword-1].e || w[0]=='=') && !hadcomma) {
 							/* cas particulier d'ecriture libre */
@@ -24860,7 +24860,7 @@ printf("%s\n",wordlist[nbword].w);
 							Automate[' ']=1;
 							Automate['\t']=1;
 						} else {
-							/* mot de fin de ligne, ï¿½ priori pas une expression */
+							/* mot de fin de ligne, à priori pas une expression */
 							curw.w=TxtStrDup(w);
 							curw.l=listing[l].iline;
 							curw.ifile=listing[l].ifile;
@@ -24879,7 +24879,7 @@ if (curw.w[0]=='=') {
 							hadcomma=0;
 						}
 					} else {
-						/* sinon c'est le prï¿½cï¿½dent qui ï¿½tait terminateur d'instruction */
+						/* sinon c'est le précédent qui était terminateur d'instruction */
 						wordlist[nbword-1].t=1;
 						w[lw]=0;
 					}
@@ -24921,7 +24921,7 @@ printf("*** patch prepro operator assignment + useless spacing\n");
 							w[lw]=0;
 						}
 					} else {
-						/* 2018.06.06 ï¿½volution sur le ! (not) */
+						/* 2018.06.06 évolution sur le ! (not) */
 #if TRACE_PREPRO
 printf("*** operateur commence le mot\n");
 printf("mot precedent=[%s] t=%d\n",wordlist[nbword-1].w,wordlist[nbword-1].t);
@@ -24931,7 +24931,7 @@ printf("mot precedent=[%s] t=%d\n",wordlist[nbword-1].w,wordlist[nbword-1].t);
 							w[lw++]=c;
 							StateMachineResizeBuffer(&w,lw,&mw);
 							w[lw]=0;
-							/* automate dï¿½jï¿½ modifiï¿½ rien de plus */
+							/* automate déjà modifié rien de plus */
 						} else if (!wordlist[nbword-1].t) {
 							/* il y avait un mot avant alors on va reorganiser la ligne */
 							/* patch NOT -> SAUF si c'est une directive */
@@ -25040,18 +25040,18 @@ printf("quote start with %c\n",c);
 					if ((unsigned char)w[utidx]>126) {
 						switch ((unsigned char)w[utidx]) {
 							case 0xC2:
-								if ((unsigned char)w[utidx+1]==0xBF) w[utidx]=174; else // ï¿½
-								if ((unsigned char)w[utidx+1]==0xA1) w[utidx]=175; else // ï¿½
+								if ((unsigned char)w[utidx+1]==0xBF) w[utidx]=174; else // ¿
+								if ((unsigned char)w[utidx+1]==0xA1) w[utidx]=175; else // ¡
 									MakeError(ae,0,ae->filename[listing[l].ifile],listing[l].iline,"Unsupported UTF8 char for quoted string\n");
 								break;
 							case 0xC3:
-								if ((unsigned char)w[utidx+1]==0xB9) w[utidx]=124; else // ï¿½
-								if ((unsigned char)w[utidx+1]==0xA9) w[utidx]=123; else // ï¿½
-								if ((unsigned char)w[utidx+1]==0xA8) w[utidx]=125; else // ï¿½
-								if ((unsigned char)w[utidx+1]==0xA0) w[utidx]=64; else  // ï¿½
-								if ((unsigned char)w[utidx+1]==0x91) w[utidx]=161; else // ï¿½
-								if ((unsigned char)w[utidx+1]==0xB1) w[utidx]=171; else // ï¿½
-								if ((unsigned char)w[utidx+1]==0xA7) {                  // ï¿½
+								if ((unsigned char)w[utidx+1]==0xB9) w[utidx]=124; else // ù
+								if ((unsigned char)w[utidx+1]==0xA9) w[utidx]=123; else // é
+								if ((unsigned char)w[utidx+1]==0xA8) w[utidx]=125; else // è
+								if ((unsigned char)w[utidx+1]==0xA0) w[utidx]=64; else  // à
+								if ((unsigned char)w[utidx+1]==0x91) w[utidx]=161; else // Ñ
+								if ((unsigned char)w[utidx+1]==0xB1) w[utidx]=171; else // ñ
+								if ((unsigned char)w[utidx+1]==0xA7) {                  // ç
 									w[utidx]=92;
 									w[utidx+1]=92; // conversion to "\\"
 								} else
@@ -25211,7 +25211,7 @@ int RasmAssembleInfoIntoRAMROM(const char *datain, int lenin, struct s_rasm_info
 
 	ae=PreProcessing(NULL,1,datain,lenin,NULL);
 
-	/* extension 4Mo = 256 slots + 4 slots 64K de RAM par dï¿½faut => 260 */
+	/* extension 4Mo = 256 slots + 4 slots 64K de RAM par défaut => 260 */
 	maxbank=ramsize>>14;
 	for (i=0;i<maxbank;i++) {
 		ramidx=i*16384;
@@ -25244,7 +25244,7 @@ int RasmAssembleInfoIntoRAM(const char *datain, int lenin, struct s_rasm_info **
 
 	ae=PreProcessing(NULL,1,datain,lenin,NULL);
 
-	/* extension 4Mo = 256 slots + 4 slots 64K de RAM par dï¿½faut => 260 */
+	/* extension 4Mo = 256 slots + 4 slots 64K de RAM par défaut => 260 */
 	maxbank=ramsize>>14;
 	for (i=0;i<maxbank;i++) {
 		ramidx=i*16384;
@@ -25293,7 +25293,7 @@ int RasmAssembleInfoParam(const char *datain, int lenin, unsigned char **dataout
 
 #define AUTOTEST_IS_REGISTER "assert is_register('bc')==1 : assert is_register('d')==1 : assert is_register('e')==1 : assert is_register('z')==0 : assert is_register('rr')==0 : nop "
 
-#define AUTOTEST_ACCENT "defb 'grouikï¿½'"
+#define AUTOTEST_ACCENT "defb 'grouiké'"
 
 #define AUTOTEST_QUOTELAST "nop : save'grouik"
 
@@ -25524,7 +25524,7 @@ int RasmAssembleInfoParam(const char *datain, int lenin, unsigned char **dataout
 #define AUTOTEST_DELAYNUM	"macro test  label:    dw {label}:    endm:    repeat 3, idx:idx2 = idx-1:" \
 				" test label_{idx2}:    rend:repeat 3, idx:label_{idx-1}:nop:rend"
 
-#define AUTOTEST_STR		"CHARSET \" !#$%&'()*+,-./0123456789:;<=>?ABCDEFGHIJKLMNOPQRSTUVWXYZ[]^~abcdefghijklmnopqrstuvwxyzï¿½ï¿½{}|\",0 : "\
+#define AUTOTEST_STR		"CHARSET \" !#$%&'()*+,-./0123456789:;<=>?ABCDEFGHIJKLMNOPQRSTUVWXYZ[]^~abcdefghijklmnopqrstuvwxyzéè{}|\",0 : "\
 				"grouik STR 'REGION' : charset : defb 'REGION'"
 
 #define AUTOTEST_STRUCT		"org #1000:label1 :struct male:age    defb 0:height defb 0:endstruct:struct female:" \


### PR DESCRIPTION
Current version of `rasm` does not respect the` -sb` and `-ss` arguments.
This patch aims at respecting them.

Current modification consists at removing the code that forces `remu`. A probable better way, would be to force `remu`  if and only if `-sb` or `-ss` are not provided. 
Such behavior would be better than the current one (always forced) or the one I suggest in this patch (never forced).

Or an alternative is to fully remove these arguments, but I think it would be a bad idea because these chunks are documented and will probably not evolve over time.

Note that I have not checked if there are side effects with this modification