### PR TITLE
Refuse {PAGE}/{PAGESET} in cartridge mode instead of silently emitting a RAM banking value

### DIFF
--- a/rasm.c
+++ b/rasm.c
@@ -6806,11 +6806,15 @@ double ComputeExpressionCore(struct s_assenv *ae,char *original_zeexpression,con
 							} else if (strncmp(ae->computectx->varbuffer+minusptr,"{PAGE}",6)==0) {
 								bank=6;
 								page=1;
+								/* in cartridge mode the gate array value is a RAM banking configuration, not a cartridge ROM page */
+								if (ae->forcecpr) MakeError(ae,GetExpIdx(ae,didx),GetExpFile(ae,didx),GetExpLine(ae,didx),"expression [%s] cannot use PAGE in cartridge mode - {PAGE} returns a RAM banking configuration, use {BANK} instead\n",TradExpression(zeexpression));
 								/* obligé de recalculer le CRC */
 								crc=GetCRC(ae->computectx->varbuffer+minusptr+bank);
 							} else if (strncmp(ae->computectx->varbuffer+minusptr,"{PAGESET}",9)==0) {
 								bank=9;
 								page=2;
+								/* in cartridge mode the gate array value is a RAM banking configuration, not a cartridge ROM page */
+								if (ae->forcecpr) MakeError(ae,GetExpIdx(ae,didx),GetExpFile(ae,didx),GetExpLine(ae,didx),"expression [%s] cannot use PAGESET in cartridge mode - {PAGESET} returns a RAM banking configuration, use {BANK} instead\n",TradExpression(zeexpression));
 								/* obligé de recalculer le CRC */
 								crc=GetCRC(ae->computectx->varbuffer+minusptr+bank);
 							} else if (strncmp(ae->computectx->varbuffer+minusptr,"{SIZEOF}",8)==0) {
@@ -9209,6 +9213,8 @@ printf("exprout=[%s]\n",expr);
 								}
 							}
 						} else if (strcmp(varbuffer,"{PAGE}$")==0) {
+							/* in cartridge mode the gate array value is a RAM banking configuration, not a cartridge ROM page */
+							if (ae->forcecpr) MakeError(ae,ae->idx,GetCurrentFile(ae),GetExpLine(ae,0),"expression [%s] cannot use PAGE in cartridge mode - {PAGE} returns a RAM banking configuration, use {BANK} instead\n",TradExpression(expr));
 							if (ae->activebank<BANK_MAX_NUMBER) {
 								if (ae->bankset[ae->activebank>>2]) {
 									tagvalue=ae->bankgate[(ae->activebank&0x1FC)+(ae->codeadr>>14)];
@@ -9220,6 +9226,8 @@ printf("exprout=[%s]\n",expr);
 								tagvalue=ae->activebank;
 							}
 						} else if (strcmp(varbuffer,"{PAGESET}$")==0) {
+							/* in cartridge mode the gate array value is a RAM banking configuration, not a cartridge ROM page */
+							if (ae->forcecpr) MakeError(ae,ae->idx,GetCurrentFile(ae),GetExpLine(ae,0),"expression [%s] cannot use PAGESET in cartridge mode - {PAGESET} returns a RAM banking configuration, use {BANK} instead\n",TradExpression(expr));
 							if (ae->activebank<BANK_MAX_NUMBER) {
 								tagvalue=ae->setgate[ae->activebank];
 								//if (ae->activebank>3) tagvalue=((ae->activebank>>2)-1)*8+0xC2; else tagvalue=0xC0;
@@ -29438,6 +29446,13 @@ int RasmAssembleInfoParam(const char *datain, int lenin, unsigned char **dataout
 #define AUTOTEST_PAGETAG3	"buildsna:bank 2:assert {bank}$==2:assert {page}$==0x7FC0:assert {pageset}$==#7FC0:" \
 							"bankset 1:org #4000:assert {bank}$==5:assert {page}$==0x7FC5:assert {pageset}$==#7FC2"
 							
+/* {PAGE}/{PAGESET} answer with a gate array RAM banking configuration, which cannot
+   page a cartridge ROM bank -> must be refused in cartridge mode, not silently emitted */
+#define AUTOTEST_PAGETAG_CPR	"buildcpr:bank 0:org 0:ld bc,{page}b5:bank 5:org #C000:b5 nop"
+#define AUTOTEST_PAGETAG_CPR2	"buildcpr:bank 5:org #C000:ld bc,{page}$"
+#define AUTOTEST_PAGESETTAG_CPR	"buildcpr:bank 0:org 0:ld bc,{pageset}b5:bank 5:org #C000:b5 nop"
+#define AUTOTEST_PAGESETTAG_CPR2	"buildcpr:bank 5:org #C000:ld bc,{pageset}$"
+
 #define AUTOTEST_SWITCH		"mavar=4:switch mavar:case 1:nop:case 4:defb 4:case 3:defb 3:break:case 2:nop:case 4:defb 4:endswitch"
 
 #define AUTOTEST_PREPRO0	"\n\n\n\n;bitch\n\nnop\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\nxor a\n\n\n\n\n\n\n\n\n\n\n\n"
@@ -31814,6 +31829,20 @@ printf("testing prefix PAGE/PAGESET 2 OK\n");
 	if (!ret) {} else {printf("Autotest %03d ERROR (page/pageset 3)\n",cpt);exit(-1);}
 	if (opcode) MemFree(opcode);opcode=NULL;cpt++;
 printf("testing prefix PAGE/PAGESET 3 OK\n");
+
+	ret=RasmAssemble(AUTOTEST_PAGETAG_CPR,strlen(AUTOTEST_PAGETAG_CPR),&opcode,&opcodelen);
+	if (ret) {} else {printf("Autotest %03d ERROR (PAGE prefix must be refused in cartridge mode)\n",cpt);exit(-1);}
+	if (opcode) MemFree(opcode);opcode=NULL;cpt++;
+	ret=RasmAssemble(AUTOTEST_PAGETAG_CPR2,strlen(AUTOTEST_PAGETAG_CPR2),&opcode,&opcodelen);
+	if (ret) {} else {printf("Autotest %03d ERROR (PAGE $ tag must be refused in cartridge mode)\n",cpt);exit(-1);}
+	if (opcode) MemFree(opcode);opcode=NULL;cpt++;
+	ret=RasmAssemble(AUTOTEST_PAGESETTAG_CPR,strlen(AUTOTEST_PAGESETTAG_CPR),&opcode,&opcodelen);
+	if (ret) {} else {printf("Autotest %03d ERROR (PAGESET prefix must be refused in cartridge mode)\n",cpt);exit(-1);}
+	if (opcode) MemFree(opcode);opcode=NULL;cpt++;
+	ret=RasmAssemble(AUTOTEST_PAGESETTAG_CPR2,strlen(AUTOTEST_PAGESETTAG_CPR2),&opcode,&opcodelen);
+	if (ret) {} else {printf("Autotest %03d ERROR (PAGESET $ tag must be refused in cartridge mode)\n",cpt);exit(-1);}
+	if (opcode) MemFree(opcode);opcode=NULL;cpt++;
+printf("testing PAGE/PAGESET refused in cartridge mode OK\n");
 
 	ret=RasmAssemble(AUTOTEST_UNDEF,strlen(AUTOTEST_UNDEF),&opcode,&opcodelen);
 	if (!ret) {} else {printf("Autotest %03d ERROR (simple undef)\n",cpt);exit(-1);}


### PR DESCRIPTION
Salut Edouard,

I ran into this while building a GX4000 cartridge, and it cost me an
evening, so here is a small patch :-)

`{PAGE}` and `{PAGESET}` answer with a Gate Array RAM banking
configuration (`&7Fxx`, `%11bbbccc`). Under `BUILDSNA` that is exactly
right, because the banks really are RAM banks. Under `BUILDCPR` it is
not usable: D6=1 selects the RAM configuration function rather than
RMR2, so the emitted value remaps RAM and the cartridge page the label
lives in never appears. And it is emitted with no diagnostic at all,
which is the part that hurt -- everything assembles cleanly and you go
looking for the bug in your own paging code.

Reproduction:

```
        buildcpr symbol
        bank 0
        org 0x0000
        ld bc,{page}b5      ; assembles to 0x7FC5, a RAM banking value
        bank 5
        org 0xC000
b5:     nop
```

```
rasm p.asm -oc p.cpr -void
```

`{bank}b5` gives `5`, which is the value you actually want there.

So the patch refuses `{PAGE}`/`{PAGESET}` when `ae->forcecpr` is set and
points at `{BANK}` in the message. Snapshot mode is untouched -- I keyed
it on `forcecpr` and nothing wider, so `BANKSET` (which defaults to
snapshot) and `buildsna CPR` (which sets `snacpr`, not `forcecpr`) both
behave exactly as before. Your existing `AUTOTEST_PAGETAG` /
`PAGETAG2` / `PAGETAG3` still pass.

The label form is guarded where the `{PAGE}`/`{PAGESET}` prefix is
parsed, which covers all three expression sites reading
`bankgate`/`setgate` from one place; the `{PAGE}$` / `{PAGESET}$` tags
needed their own guard. I added four autotests, one per spelling.

One thing worth your judgement: a bare `BANK n` with no build directive
selects cartridge output by default, so the error also fires in sources
that never write `buildcpr`. That is correct as far as I can tell -- the
output really is a cartridge -- but it is the one case where the new
message shows up somewhere slightly surprising. Happy to soften it to a
warning if you prefer.

Checked on top of `master` at `b222469`, `-autotest` shows no new
failures (058 and the ZX0 one already fail there for me before any
change).

Merci pour RASM, as always.

Frank
