### PR TITLE
Honour LOCALISATION inside a numbered bank when exporting REMU in cartridge mode

### DIFF
--- a/rasm.c
+++ b/rasm.c
@@ -24057,6 +24057,8 @@ unsigned char * _internal_export_REMU(struct s_assenv *ae, unsigned int *rchksiz
 			if (ae->breakpoint[i].bank<256) {
 				lbankn=ae->breakpoint[i].bank;
 				isrom=1;
+				/* LOCALISATION may retarget a numbered bank: assembled in a cartridge ROM bank, but executed elsewhere */
+				for (m=0;m<ae->imemory_localisation;m++) if (ae->memory_localisation[m].physical==ae->breakpoint[i].bank) {lbankn=ae->memory_localisation[m].logical;isrom=ae->memory_localisation[m].rom;break;}
 			} else {
 				lbankn=-1; // we cannot know which memory bank
 				isrom=0;   // unless we found a mapping
@@ -24088,6 +24090,8 @@ unsigned char * _internal_export_REMU(struct s_assenv *ae, unsigned int *rchksiz
 			if (ae->label[i].ibank<256) {
 				lbankn=ae->label[i].ibank;
 				isrom=1;
+				/* LOCALISATION may retarget a numbered bank: assembled in a cartridge ROM bank, but executed elsewhere */
+				for (m=0;m<ae->imemory_localisation;m++) if (ae->memory_localisation[m].physical==ae->label[i].ibank) {lbankn=ae->memory_localisation[m].logical;isrom=ae->memory_localisation[m].rom;break;}
 			} else {
 				lbankn=-1; // we cannot know which memory bank
 				isrom=0;


### PR DESCRIPTION
Salut Edouard,

Second small one from the same cartridge project, this time in the
`REMU` export :-)

`_internal_export_REMU` takes a shortcut for numbered banks in cartridge
mode: `ibank<256` means `lbankn=ibank` and `isrom=1`, without ever
looking at `memory_localisation`. The table is only consulted in the
`else` branch, for the temporary spaces a parameterless `BANK` opens.
The snapshot path does do the lookup for numbered banks (`ibank<260`),
so the two paths disagree.

What that means in practice: code assembled into a cartridge ROM bank
but copied to RAM at boot and executed there gets exported as a ROM
label at the ROM bank, so the emulator resolves symbols and breakpoints
against an address the code never actually runs at. `LOCALISATION` is
accepted without a word and has no effect whatsoever -- I diffed the
`.cpr` with and without it and the files are byte-identical.
`__LOCALISATION` records the entry just fine, it is only this path that
ignores it.

Reproduction:

```
        buildcpr symbol
        bank 0
        org 0x0000
boot:   nop
        bank 4
        org 0x8400, 0xC000
        LOCALISATION RAM,1
staged: jp staged
```

```
rasm p.asm -oc p.cpr -rasm out -void
```

`out.rasm` gives `romlabel STAGED 33792 4` with the `LOCALISATION` line,
without it, and with `LOCALISATION ROM,7` too -- all three identical. I
expected `label STAGED 33792 1` for the first.

The patch adds the same lookup to the numbered-bank branch, for both the
breakpoint and the label export. I deliberately kept the `isrom=1`
default rather than copying the snapshot branch wholesale -- that one
defaults to `isrom=0`, and taking it over here would turn every
cartridge label into a RAM label. Only a matching `LOCALISATION` entry
overrides it now.

No autotest for this one, sorry: `s_debug_symbol` carries a name and a
value only, so the `romlabel` vs `label` distinction is not visible
through `RasmAssembleInfo`. I did not want to widen the public struct
for a test. I have it covered locally by diffing the `-rasm` export, and
if you would like that shape of check inside `-autotest` I am happy to
have a go at it.

Four added lines, on top of `master` at `b222469`, no new `-autotest`
failures.

Frank
